### PR TITLE
Add templates for issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is, including error messages.
+
+## To Reproduce
+
+Steps to reproduce the behavior. Attach any input file that might be required.
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+
+If applicable, add screenshots to help explain your problem.
+
+## Context
+
+Please, complete the following to better understand the system you are using to run MUSE.
+
+- Operating system (eg. Windows 10):
+- Auto-CORPus version (eg. 1.0.0):
+- Installation method (eg. pipx, pip, development mode):
+- Python version (you can get this running `python --version`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+## Is your feature request related to a problem? Please describe
+
+A clear and concise description of what the problem is. E.g. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Add two issue templates: one for bugs and another for feature requests.
This will mean that users are prompted to choose one when they open an
issue on GitHub.

Closes #40.
