### PR TITLE
Fix: Ignore mkdocs warnings on deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Build docs with MkDocs
-        run: poetry run mkdocs build --strict
+        run: poetry run mkdocs build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact


### PR DESCRIPTION
There are currently a bunch of docstring-related warnings emitted by mkdocs. If you build with `--strict` then the process will fail, so let's not.

Fixes #50