### PR TITLE
Use pathlib for path handling

### DIFF
--- a/src/autoCORPus.py
+++ b/src/autoCORPus.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import sys
+from pathlib import Path
 
 from bioc import loads, dumps, BioCFileType
 from bs4 import BeautifulSoup
@@ -37,28 +38,32 @@ class autoCORPus:
 
     @handle_path
     def __read_config(self, config_path):
-        with open(config_path, "r") as f:
+        config_path = Path(config_path)
+        with config_path.open("r") as f:
             ## TODO: validate config file here if possible
             content = json.load(f)
             return content["config"]
 
     @handle_path
     def __import_file(self, file_path):
-        with open(file_path, "r") as f:
+        file_path = Path(file_path)
+        with file_path.open("r") as f:
             return f.read(), file_path
 
     @handle_path
     def __handle_target_dir(self, target_dir):
-        if not os.path.exists(target_dir):
-            os.makedirs(target_dir)
+        target_dir = Path(target_dir)
+        if not target_dir.exists():
+            target_dir.mkdir(parents=True)
         return
 
     def __validate_infile(self):
         pass
 
     def __soupify_infile(self, fpath):
+        fpath = Path(fpath)
         try:
-            with open(fpath, "r", encoding="utf-8") as fp:
+            with fpath.open("r", encoding="utf-8") as fp:
                 soup = BeautifulSoup(fp.read(), 'html.parser')
                 for e in soup.find_all(attrs={'style': ['display:none', 'visibility:hidden']}):
                     e.extract()

--- a/src/table_image.py
+++ b/src/table_image.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 from operator import itemgetter
+from pathlib import Path
 
 import cv2
 import pytesseract
@@ -389,13 +390,15 @@ class table_image:
             "infons": {},
             "documents": []
         }
+        base_dir = Path(base_dir)
         for image_path in table_images:
-            imgname = image_path.split('/')[-1]
+            image_path = Path(image_path) 
+            imgname = image_path.name
             self.tableIdentifier = imgname.split("_")[-1].split(".")[0]
-            self.file_name = imgname.replace(base_dir + "/", "")
-            pmc = imgname[0:imgname.rfind('.')]
+            self.file_name = str(image_path.relative_to(base_dir))
+            pmc = imgname.stem
 
-            img = cv2.imread(image_path)
+            img = cv2.imread(str(image_path))
 
             cells, added, thresh = self.find_cells(img)
             table_row = self.cell2table(cells, added, thresh, "imagesOut", pmc)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,6 +1,6 @@
-import os
 import re
 import unicodedata
+from pathlib import Path
 
 import bs4
 import networkx as nx
@@ -21,13 +21,13 @@ def get_files(base_dir, pattern=r'(.*).html'):
         file_list: a list of filepath
     """
     file_list = []
-    files = os.listdir(base_dir)
-    for i in files:
-        abs_path = os.path.join(base_dir, i)
-        if re.match(pattern, abs_path):
-            file_list.append(abs_path)
-        elif os.path.isdir(abs_path) & ('ipynb_checkpoints' not in abs_path):
-            file_list += get_files(abs_path)
+    base_dir = Path(base_dir)
+    for item in base_dir.iterdir():
+        abs_path = item.resolve()
+        if abs_path.is_file() and re.match(pattern, str(abs_path)):
+            file_list.append(str(abs_path))
+        elif abs_path.is_dir() and 'ipynb_checkpoints' not in str(abs_path):
+            file_list += get_files(abs_path, pattern)
     return file_list
 
 

--- a/tests/quick_comparison.py
+++ b/tests/quick_comparison.py
@@ -1,37 +1,35 @@
-import os
 import re
+from pathlib import Path
 
-folder1_path = 'OldOutput'
-folder2_path = 'NewOutput'
+folder1_path = Path('OldOutput')
+folder2_path = Path('NewOutput')
 lines_to_ignore = ["\"date\":", "\"offset\":", "\"inputfile\":"]
 
 different_files = []
 
-for root, dirs, files in os.walk(folder1_path):
-    for filename in files:
-        if "_bioc" not in filename:
-            continue
-        folder1_file_path = os.path.join(root, filename)
-        folder2_file_path = os.path.join(folder2_path, filename)
-        if os.path.exists(folder2_file_path):
-            with open(folder1_file_path, 'r') as f1, open(folder2_file_path, 'r') as f2:
-                lines1 = f1.readlines()
-                lines2 = f2.readlines()
-                different_lines = [i for i, (line1, line2) in enumerate(zip(lines1, lines2)) if
-                                   re.sub(r"\s+", "", line1, flags=re.UNICODE) != re.sub(r"\s+", "", line2,
-                                                                                         flags=re.UNICODE) and
-                                   not [x for x in lines_to_ignore if x in line1]]
-                false_positives = different_lines
-                different_lines = []
-                for i in range(len(false_positives)):
-                    if "[PMC free article]" not in lines1[false_positives[i]] and "[PMC free article]" in lines2[
-                        false_positives[i]]:
-                        continue
-                    else:
-                        different_lines.append(false_positives[i])
+for folder1_file_path in folder1_path.rglob('*'):
+    if "_bioc" not in folder1_file_path.name:
+        continue
+    folder2_file_path = folder2_path / folder1_file_path.name
+    if folder2_file_path.exists():
+        with open(folder1_file_path, 'r') as f1, open(folder2_file_path, 'r') as f2:
+            lines1 = f1.readlines()
+            lines2 = f2.readlines()
+            different_lines = [
+                i for i, (line1, line2) in enumerate(zip(lines1, lines2)) 
+                if re.sub(r"\s+", "", line1, flags=re.UNICODE) != re.sub(r"\s+", "", line2, flags=re.UNICODE) and
+                not [x for x in lines_to_ignore if x in line1]
+            ]
+            false_positives = different_lines
+            different_lines = []
+            for i in range(len(false_positives)):
+                if "[PMC free article]" not in lines1[false_positives[i]] and "[PMC free article]" in lines2[false_positives[i]]:
+                    continue
+                else:
+                    different_lines.append(false_positives[i])
 
-                if different_lines:
-                    different_files.append(filename)
+            if different_lines:
+                different_files.append(folder1_file_path.name)
 
 print("\n".join(different_files))
 print(len(different_files))


### PR DESCRIPTION
This PR aims to make full use of the inbuilt `pathlib` module to handle paths, which were previously being passed around as strings. Mostly this is to ensure compatibility on different operating systems, but the syntax is also tidier and makes the code a bit more readable.

The tests pass locally, although the testing suite is minimal, so I'm sure someone will want to try this out more thoroughly before merging

Close #39 