### PR TITLE
Tweaks to pre-commit configuration

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# For list of markdownlint rules, see: https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
+MD013: false
+MD033: false
+MD036: false
+MD040: false
+MD041: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+exclude: ^tests/data/
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -34,4 +35,3 @@ repos:
     hooks:
       - id: codespell
         args: [-I, .codespell_ignore.txt]
-        exclude: ^tests/data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
     rev: v0.41.0
     hooks:
       - id: markdownlint-fix
-        args: [--disable, MD013, MD033, MD036, MD041, MD040, --]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/docs/config_tutorial.md
+++ b/docs/config_tutorial.md
@@ -105,7 +105,7 @@ the HTML is generated from each source without having to define exact matches fo
 The second example identifies all `header` elements ranging from `<h3>` to `<h6>`. Auto-CORPus will process all matching
 headers at the same time.
 
-Within the first example, notice the use of "\\\d" instead of the usual "\d" for identifying any digit. This is due to the regex pattern being defined within the config which is a JSON file. For further information about escapaing special characters within JSON have a look at [this guide by tutorials point](https://www.tutorialspoint.com/json_simple/json_simple_escape_characters.htm).
+Within the first example, notice the use of "\\\d" instead of the usual "\d" for identifying any digit. This is due to the regex pattern being defined within the config which is a JSON file. For further information about escaping special characters within JSON have a look at [this guide by tutorials point](https://www.tutorialspoint.com/json_simple/json_simple_escape_characters.htm).
 
 <h3><a name="submit">Submitting/editing config files</a></h3>
 

--- a/tests/data/PMC8885717.html
+++ b/tests/data/PMC8885717.html
@@ -1,5 +1,5 @@
 
-
+    
 <!DOCTYPE html>
 
 
@@ -15,15 +15,15 @@
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-
+  
     <!-- Stylesheets -->
     <link rel="stylesheet" href="/pmc/static/CACHE/css/output.4fcebe760087.css" type="text/css">
-
+  
   <link rel="stylesheet" href="/pmc/static/CACHE/css/output.75c4eebe6760.css" type="text/css"><link rel="stylesheet" href="/pmc/static/CACHE/css/output.e6ffed46fa81.css" type="text/css"><link rel="stylesheet" href="/pmc/static/CACHE/css/output.3766d7ad0d2d.css" type="text/css"><link rel="stylesheet" href="/pmc/static/CACHE/css/output.e3c3c2c84eb3.css" type="text/css">
 
-
+  
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css"/>
-
+  
 <link type="text/css" href="/pmc/static/bundles/base/base.a2ef7ca69e4b20dff539.css" rel="stylesheet" />
 
 
@@ -35,7 +35,7 @@
 
     <title>Auto-CORPus: A Natural Language Processing Tool for Standardizing and Reusing Biomedical Literature - PMC</title>
 
-
+  
   <!-- Favicons -->
   <link rel="shortcut icon" type="image/ico" href="https://www.ncbi.nlm.nih.gov/coreutils/nwds/img/favicons/favicon.ico" />
   <link rel="icon" type="image/png" href="https://www.ncbi.nlm.nih.gov/coreutils/nwds/img/favicons/favicon.png" />
@@ -56,7 +56,7 @@
 
 
 
-
+    
         <!-- Logging params: Pinger defaults -->
 
 <meta name="ncbi_app" content="pmc-frontend" />
@@ -81,13 +81,13 @@
 <meta name="ncbi_pcid" content="/articles/PMC8885717/" />
 
 
-
+    
 
 
     <script>
-
+        
             var ncbiBaseUrl = "https://www.ncbi.nlm.nih.gov";
-
+        
         var useOfficialGovtHeader = true;
     </script>
 
@@ -98,15 +98,15 @@
 </head>
 <body >
 
-
-
+   
+    
         <button
           class="back-to-top back-to-top--bottom"
           data-ga-category="pagination"
           data-ga-action="back_to_top">
           Back to Top
         </button>
-
+    
 
     <a class="usa-skipnav" href="#main-content">Skip to main content</a>
     <!-- ========== BEGIN HEADER ========== -->
@@ -222,15 +222,15 @@
 </section>
 <!-- ========== END HEADER ========== -->
 
+    
+    
 
 
-
-
-
-
+    
+        
 
 <section class="pmc-alerts">
-
+    
     <div role="alert" class="pmc-alert pmc-alert--info" role="region" aria-label="Alert" aria-hidden="false"  data-key="pmc-alert-welcome">
         <div class="pmc-alert__body pmc-alert--ncbi-icon">
             <div class="pmc-alert__content">
@@ -244,24 +244,24 @@
             </div>
         </div>
     </div>
-
+    
 </section>
+    
 
-
-
-
-
+    
+    
+        
         <header class="pmc-header usa-header-extended" role="banner">
     <div class="pmc-header__bar">
         <div class="pmc-header__control usa-accordion">
-
+            
                 <button class="usa-menu-btn pmc-header--button pmc-header--left">
                     <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
                 </button>
-
+            
 
             <div class="usa-logo pmc-header__logo pmc-header--stretch
-
+                
                " id="extended-mega-logo">
                 <div class="usa-logo-text">
                     <a href="/pmc/" title="Home" aria-label="Home" ></a>
@@ -313,43 +313,43 @@
             <i class="fa fa-times" aria-hidden="true"></i>
         </button>
         <div class="usa-breadcrumb usa-breadcrumb--wrap usa-breadcrumb--hack">
-
+             
     <ul class="usa-breadcrumb__list">
-
+            
                 <li class="usa-breadcrumb__list-item"
                     >
                     <a href="/pmc/journals/" class="navlink">Journal List</a>
                 </li>
-
+            
                 <li class="usa-breadcrumb__list-item"
                     >
                     <a href="/pmc/?term=%22Front%20Digit%20Health%22[journal]" class="navlink">Front Digit Health</a>
                 </li>
-
+            
                 <li class="usa-breadcrumb__list-item"
                      aria-current="page" >
                     PMC8885717
                 </li>
-
+            
     </ul>
-
+ 
 
         </div>
-
-
+        
+        
             <div class="pmc-sidebar pmc-sidebar-hack">
-
+                
 
 <div class="scroller">
 
-
+    
         <section>
                 <h6>Other Formats</h6>
                 <ul class="pmc-sidebar__formats">
                   <li class="pdf-link other_item"><a href="/pmc/articles/PMC8885717/pdf/fdgth-04-788124.pdf" class="int-view">PDF (2.7M)</a></li>
                 </ul>
         </section>
-
+    
     <section>
         <h6>Actions</h6>
         <ul class="pmc-sidebar__actions">
@@ -364,8 +364,8 @@
                 </button>
             </li>
             <li>
-
-
+                
+                    
 
 <link type="text/css" href="ncbi-overlay-block/src/overlay-block.css">
 <div class="collections-button-container" data-article-id="8885717" data-article-db="pmc">
@@ -385,7 +385,7 @@
        aria-hidden="true">
     <div class="title">Add to Collections</div>
     <div class="collections-action-panel action-panel">
-
+      
 
 
 <form id="collections-action-dialog-form"
@@ -398,7 +398,7 @@
 
   <input type="hidden" name="csrfmiddlewaretoken" value="lyoBdak3TySdV2Pk7demx2dF10auTwlTzOqnaZr8odGkmGXu8bNK8X8OAWVrnOzk">
 
-
+  
 
   <div class="choice-group" role="radiogroup">
     <ul class="radio-group-items">
@@ -490,16 +490,16 @@
   </div>
 </div>
 </div>
-
+                
             </li>
 
         </ul>
     </section>
-
+    
         <section class="social-sharing">
             <h6>Share</h6>
             <ul class="pmc-sidebar__share">
-                <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F&amp;text=Auto-CORPus%3A%20A%20Natural%20Language%20Processing%20Tool%20for%20Standardizing%20and%20Reusing%20Biomedical%20Literature" alt="Share on Twitter"><i class="fa fa-twitter fa-stack-1x">&#160;</i></a></li>
+                <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F&amp;text=Auto-CORPus%3A%20A%20Natural%20Language%20Processing%20Tool%20for%20Standardizing%20and%20Reusing%20Biomedical%20Literature" alt="Share on Twitter"><i class="fa fa-twitter fa-stack-1x">&#160;</i></a></li> 
 <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F" alt="Share on Facebook"><i class="fa fa-facebook fa-stack-1x">&#160;</i></a></li>
                 <li>
                     <div class="share-permalink">
@@ -522,11 +522,11 @@
                 </li>
             </ul>
         </section>
-
+    
     <section>
         <h6>RESOURCES</h6>
         <ul class="pmc-sidebar__resources">
-
+        
             <li>
                 <div class="usa-accordion">
                     <button
@@ -542,12 +542,12 @@
                         Similar articles
                     </button>
                     <div
-
+                            
                                 data-source-url="/pmc/resources/similar-article-links/35243479/"
-
+                            
 
                          class="usa-accordion-content pmc-sidebar__resources--citations" id="similar-articles-accordion-header" aria-hidden="true">
-
+                        
                     </div>
                 </div>
             </li>
@@ -566,14 +566,14 @@
                         Cited by other articles
                     </button>
                     <div
-
+                            
                                 data-source-url="/pmc/resources/cited-by-links/35243479/"
-
+                            
                             class="usa-accordion-content pmc-sidebar__resources--citations"
                             id="cited-by-accordion-header"
                             aria-hidden="true"
                     >
-
+                        
                     </div>
                 </div>
             </li>
@@ -595,50 +595,50 @@
                 </div>
             </li>
 
-
-
+            
+        
         </ul>
     </section>
 
  </div>
             </div>
-
+        
 
     </nav>
 
 </header>
 
-
-
+    
+    
 
     <div class="usa-overlay"></div>
-
+    
 <main id="main-content" class="usa-grid usa-layout-docs pmc-main">
     <article class="usa-width-three-fourths usa-layout-docs-main_content pmc-article">
         <section class="usa-breadcrumb usa-breadcrumb--wrap">
-
+         
     <ul class="usa-breadcrumb__list">
-
+            
                 <li class="usa-breadcrumb__list-item"
                     >
                     <a href="/pmc/journals/" class="navlink">Journal List</a>
                 </li>
-
+            
                 <li class="usa-breadcrumb__list-item"
                     >
                     <a href="/pmc/?term=%22Front%20Digit%20Health%22[journal]" class="navlink">Front Digit Health</a>
                 </li>
-
+            
                 <li class="usa-breadcrumb__list-item"
                      aria-current="page" >
                     PMC8885717
                 </li>
-
+            
     </ul>
-
+ 
 
         </section>
-
+        
   <div class="pmc-article__disclaimer" role="complementary" aria-label="Disclaimer note">
     As a library, NLM provides access to scientific literature. Inclusion in an NLM database does not imply endorsement of, or agreement with,
     the contents by NLM or the National Institutes of Health.<br/>
@@ -651,14 +651,14 @@
 </div>
 
         <section class="pmc-page-banner" role="banner">
-
-
-                    <div><img src="/corehtml/pmc/pmcgifs/logo-fdh.png" alt="Logo of fdh" usemap="#logo-imagemap" /><map id="logo-imagemap" name="logo-imagemap"><area alt="Link to Publisher's site" title="Link to Publisher's site" shape="default" coords="0,0,499,74" href="https://www.frontiersin.org/journals/digital-health" target="_blank" rel="noopener noreferrer" ref="reftype=publisher&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CBanner&amp;TO=Publisher%7COther%7CN/A" /></map></div>
-
-
+            
+                
+                    <div><img src="/corehtml/pmc/pmcgifs/logo-fdh.png" alt="Logo of fdh" usemap="#logo-imagemap" /><map id="logo-imagemap" name="logo-imagemap"><area alt="Link to Publisher's site" title="Link to Publisher's site" shape="default" coords="0,0,499,74" href="https://www.frontiersin.org/journals/digital-health" target="_blank" rel="noopener noreferrer" ref="reftype=publisher&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CBanner&amp;TO=Publisher%7COther%7CN/A" /></map></div> 
+                
+            
         </section>
         <section  role="document">
-
+            
                 <div id="mc" class=" article lit-style content pmc-wm slang-all page-box"><!--main-content--><div class="jig-ncbiinpagenav" data-jigconfig="smoothScroll: false, allHeadingLevels: ['h2'], headingExclude: ':hidden,.nomenu'"><div class="fm-sec half_rhythm no_top_margin"><div class="fm-flexbox"><div class="fm-citation"><div class="citation-default"><div class="part1"><span id="pmcmata">Front Digit Health.</span> 2022; 4: 788124. </div><div class="part2"><span class="fm-vol-iss-date">Published online 2022 Feb 15. </span>  <span class="doi"><span>doi: </span><a href="//doi.org/10.3389%2Ffdgth.2022.788124" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CFront%20Matter&amp;TO=Content%20Provider%7CCrosslink%7CDOI">10.3389/fdgth.2022.788124</a></span></div></div></div><div class="fm-ids"><div class="fm-citation-pmcid"><span class="fm-citation-ids-label">PMCID: </span><span>PMC8885717</span></div><div class="fm-citation-pmid">PMID: <a href="https://pubmed.ncbi.nlm.nih.gov/35243479">35243479</a></div></div></div><h1 class="content-title">Auto-CORPus: A Natural Language Processing Tool for Standardizing and Reusing Biomedical Literature</h1><div class="half_rhythm"><div class="contrib-group fm-author"><a href="https://pubmed.ncbi.nlm.nih.gov/?term=Beck%20T%5BAuthor%5D" class="affpopup" co-rid="_co_idm140676496310000" co-class="co-affbox">Tim Beck</a>,<sup><img src="/corehtml/pmc/pmcgifs/corrauth.gif" alt="corresponding author" /></sup><sup>
 1
 ,</sup><sup>
@@ -755,23 +755,23 @@
 <strong>PMC</strong>
 </th></tr></thead><tbody><tr><td valign="top" align="left" rowspan="1" colspan="1">Section titles</td><td valign="top" align="left" rowspan="1" colspan="1">Section titles, subtitles, subsubtitles (and so on) are linked to the passage text they apply to</td><td valign="top" align="left" rowspan="1" colspan="1">Section titles, subtitles, subsubtitles (and so on) precede the passage text they apply to</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Section types</td><td valign="top" align="left" rowspan="1" colspan="1">Section types are annotated using IAO terms</td><td valign="top" align="left" rowspan="1" colspan="1">Section types are described using custom labels</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Offset counts</td><td valign="top" align="left" rowspan="1" colspan="1">Offset increased by 1 for every character (including whitespace) in a passage</td><td valign="top" align="left" rowspan="1" colspan="1">Offset increased by the number of bytes in the text of a passage plus one space</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Table and figure sections</td><td valign="top" align="left" rowspan="1" colspan="1">Structured table data are stored in table JSON. Figure captions are included in the BioC JSON in the sequential order in which they occur within paragraphs.</td><td valign="top" align="left" rowspan="1" colspan="1">Table data and figure captions occur at the end of the JSON document. Table content is given as XML.</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Abbreviations section</td><td valign="top" align="left" rowspan="1" colspan="1">Abbreviations section stored in abbreviations JSON. Abbreviation and definition components are related. Incomplete/one-sided definitions are not stored.</td><td valign="top" align="left" rowspan="1" colspan="1">Abbreviations and definitions from the abbreviations section are stored separately as text with no relations between the two components. Incomplete/one-sided definitions are stored.</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Link anchor text</td><td valign="top" align="left" rowspan="1" colspan="1">Link anchor text retained (HTML element tags removed).</td><td valign="top" align="left" rowspan="1" colspan="1">Link anchor text removed.</td></tr><tr><td valign="top" align="left" rowspan="1" colspan="1">Character encoding</td><td valign="top" align="left" rowspan="1" colspan="1">UTF-8 used for outputs</td><td valign="top" align="left" rowspan="1" colspan="1">Available in Unicode and ASCII</td></tr></tbody></table></div><div class="largeobj-link align_right" id="largeobj_idm140676492687024"><a target="object" rel="noopener" href="/pmc/articles/PMC8885717/table/T4/?report=objectonly">Open in a separate window</a></div></div><p>The Auto-CORPus BioC output includes the figure captions where they appear in the text and a separate table JSON file to store the table data, whereas the PMC BioC adds these data at the end of the JSON document and provides table content as a block of XML. Abbreviation sections are not included in the Auto-CORPus BioC output since Auto-CORPus provides a dedicated abbreviations JSON output. In the PMC BioC format the abbreviations and definitions are not related, whereas in the Auto-CORPus abbreviations JSON output the two elements are related. If an abbreviation does not contain a definition in the abbreviations section (perhaps due to an editorial error), PMC BioC will include the undefined thus meaningless abbreviation string, whereas Auto-CORPus will ignore it. Link anchor text to figures, tables, references and URLs are retained in the Auto-CORPus output but removed in the PMC BioC output. The most common differences between the two BioC versions is the encodings/strings used to reflect different whitespace characters and other special characters, with the remaining content being identical.</p><p>The proportion of characters from 9,468 full-text paragraphs in the publisher dataset that also appear in the Auto-CORPus PMC BioC dataset in the same order in the paragraph string were evaluated. The median and interquartile range of the (left-skewed) similarity is also 100 and 100&#x02013;100%, respectively, and differences between the PMC and publisher-versions are the same as those previously observed and reported in <a href="/pmc/articles/PMC8885717/table/T4/" target="table" class="fig-table-link figpopup" rid-figpopup="T4" rid-ob="ob-T4" co-legend-rid=""><span>Table 4</span></a>.</p><p class="p">Last, we evaluated the section title mapping to IAO terms for publication from non-biomedical domains (physics, psychology). We observed that not all publications from these domains have standardized headers that can be mapped directly or with fuzzy matching and require the digraph to map headers. Most headers are mapped correctly either to one or multiple (potential) IAO terms (<a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Table 1</a>). Only one publication contained a mismatch where two sections were mapped to introduction and methods sections, respectively, where each of these contained sub-headers that relate to introduction, methods and results. In two physics publications we encountered the case where the &#x0201c;proportional to&#x0201d; sign (&#x0221d;) could not be mapped by the encoder.</p><div id="sec-a.s.c.c.g" class="sec sec-last"><p></p><h4 id="sec-a.s.c.c.gtitle" class="inline">Performance of Auto-CORPus Table Processing </h4><p class="p p-first">We assessed the accuracy of the table JSON output generated from non-PMC linked tables compared with table JSON output generated from the equivalent PMC HTML with inline tables. The comparative analysis method described above was used for comparing BioC output from the linked table and inline table datasets, except here it was applied to both strings (bidirectional, taking the maximum value of both outcomes). This is equivalent to the Levenshtein similarity applied to transform the larger string into the smaller string, with the exception that the different characters for both comparisons are retained for identifying the differences. The correspondence between table JSON files in the linked table and inline table datasets was calculated as the number of characters correctly represented in the publishers table JSON output relative to the PMC versions [also using the (symmetric) longest common subsequence method]. Both the text and table similarity are represented as the median (inter-quartile range) to account for non-normal distributions of the data. Any differences identified during these analyses were at the paragraph or table row level, enabling manual investigation of these sections in a side-by-side comparison of the files.</p><p class="p p-last">The proportion of characters from 367 tables in the linked table dataset that also appear in the inline table dataset in the same order in the cell or text string were evaluated. The median and interquartile range of the (left-skewed) similarity is 100 and 99.79&#x02013;100.00%, respectively. We found that there were structural differences between some of the output files where additional data rows were present in the JSON files generated from the publisher's files. This occurred because cell value strings in tables from the publisher's files were split across two rows, however in the PMC version the string was formatted (wrapped) to be contained within a single row. The use of different table structures to contain the same data resulted in accurate but differing table JSON outputs. Most of the differences between table content and metadata values pertain to the character encoding used in the different table versions. For example, we have found different uses of hyphen/em dash/en dash/minus symbols between different versions, and Greek letters were represented differently in the different table versions. Other differences are related to how numbers are represented in scientific notation. If a cell contains a number only, then it is represented as a JSON number data type in the output. However, if the cell contains non-numeric characters, then there is no standardization of the cell text and the notation used (e.g., the &#x000d7; symbol or E notation) will be reproduced in the JSON output. When there is variation in notation between sources, the JSON outputs will differ. Other editorial differences include whether thousands are represented with or without commas and how whitespace characters are used. Despite these variations there was no information loss between processed inline and linked tables.</p></div></div><div id="sec-a.s.c.d" class="sec sec-last"><h3 id="sec-a.s.c.dtitle">Application: NER on GWAS Publications</h3><p class="p p-first-last">Our intention is that Auto-CORPus supports information extraction from the biomedical literature. To demonstrate the use of Auto-CORPus outputs within a real-world application and aligned to the authors' expertise to support the evaluation of the results, we applied named-entity recognition (NER) to the Auto-CORPus BioC full-text output to extract GWAS metadata. Study metadata are included in curated GWAS databases, such as GWAS Central, and the ability to extract these entities automatically could provide a valuable curation aid. Full details of the method and the rationale behind the application is provided in the <a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Methods</a>. In summary, we filtered out sentences in the methods sections from the BioC full-text output that contain information on the genotyping platforms, assays, total number of genetic variants, quality control and imputation that were used. We trained five separate algorithms for NER (one for each metadata type) using 700 GWAS publications and evaluated these on 500 GWAS publications of the test set. The F1-scores for the five tasks are between 0.82 and 1.00 (<a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Table 2</a>) with examples given in <a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Figure 4</a>.</p></div></div><div id="s4" class="tsec sec"><h2 class="head no_bottom_margin" id="s4title">Discussion</h2><div id="sec-a.s.d.b" class="sec sec-first"><h3 id="sec-a.s.d.btitle">Strengths and Limitations</h3><p class="p p-first">We have shown that Auto-CORPus brings together and bolsters several disjointed standards (BioC and IAO) and algorithmic components (for processing tables and abbreviations) of scientific literature analytics into a convenient and reliable tool for standardizing full-text and tables. The BioC format is a useful but not ubiquitous standard for representing text and annotations. Auto-CORPus enables the transformation of the widely available HTML format into BioC JSON following the setup of a configuration file associated with the structure of the HTML documents. The use of the configuration file drives the flexibility of the package, but also restricts use to users who are confident exploring HTML document structures. We make available the configuration files used in the evaluations described in this paper. To process additional sources, an upfront time investment is required from the user to explore the HTML structure and set the configuration file. We will be increasing the number of configuration files available for larger publishers, and we help non-technical users by providing documentation to explain how to setup configuration files. We welcome configuration files submitted by users and the documentation describes the process for users to submit files. Configuration files contain a section for tracking contributions made to the file, so the names of authors and editors can be logged. Once a configuration file has been submitted and tested, the file will be included within the Auto-CORPus package and the user credited (should they wish) with authorship of the file.</p><p>The inclusion of IAO terms within the Auto-CORPus BioC output standardizes the description of publication sections across all processed sources. The digraph that is used to assign unmapped paragraph headers to standard IAO terms was constructed using both GWAS and MWAS literature to avoid training it to be used for a single domain only. We have tested the algorithms on PMC articles from three different physics and three psychology journals to confirm the BioC JSON output and IAO term recognition extend beyond only biomedical literature. Virtually all header terms from these articles were mapped to relevant IAO terms even when not all headers could be mapped, however some sections were mapped to multiple IAO terms based on paths in the digraph. Since ontologies are stable but not static, any resource or service that relies on one ontology structure could become outdated or redundant as the ontology is updated. We will rerun the fuzzy matching of headers to IAO terms and regenerate the digraph as new terms are introduced to the <em>document part</em> branch of IAO. We have experience of this when our first group of term suggestions based on the digraph were included into the IAO.</p><p>The BioC output of abbreviations contains the abbreviation, definition and the algorithm(s) by which each pair was identified. One limitation of the current full-text abbreviation algorithm is that it searches for abbreviations in brackets and therefore will not find abbreviations for which the definition is in brackets, or abbreviations that are defined without use of brackets. The current structure of the abbreviation JSON allows additional methods to be included alongside the two methods currently used. Adding further algorithms to find different types of abbreviation in the full-text is considered as part of future work.</p><p>Auto-CORPus implements a method for extracting table structures and data that was developed to extract table information from XML formatted tables (<a href="#B8" rid="B8" class=" bibr popnode">8</a>). The use of the configuration file for identifying table containers enables the table processing to be focused on relevant data tables and exclude other tables associated with web page formatting. Auto-CORPus is distinct from other work in this field that uses machine learning methods to classify the types of information within tables (<a href="#B16" rid="B16" class=" bibr popnode">16</a>). Auto-CORPus table processing is agnostic to the extracted variables, with the only distinction made between numbers and strings for the pragmatic reason of correctly formatting the JSON data type. The table JSON files could be used in downstream analysis (and annotation) of cell information types, but the intention of Auto-CORPus is to provide the capability to generate a faithful standardized output from any HTML source file. We have shown high accuracy (&#x0003e;99%) for the tables we have processed with a configuration file and the machine learning method was shown to recover data from ~86% of tables (<a href="#B16" rid="B16" class=" bibr popnode">16</a>). Accurate extraction is possible across more data sources with the Auto-CORPus rule-based approach, but a greater investment in setup time is required.</p><p class="p p-last">Auto-CORPus focuses on HTML versions of articles as these are readily and widely available within the biomedical domain. Currently the processing of PDF documents is not supported, but the work by the Semantic Scholar group to convert PDF documents to HTML is encouraging as they observed that 87% of PDF documents processed showed little to no readability issues (<a href="#B4" rid="B4" class=" bibr popnode">4</a>). The ability to leverage reliable document transformation will have implications for processing supplementary information files and broader scientific literature sources which are sometimes only available in PDF format, and therefore will require conversion to the accessible and reusable HTML format.</p></div><div id="sec-a.s.d.c" class="sec sec-last"><h3 id="sec-a.s.d.ctitle">Future Research and Conclusions</h3><p class="p p-first">We found that the tables for some publications are made available as images (see <a href="/pmc/articles/PMC8885717/table/T1/" target="table" class="fig-table-link figpopup" rid-figpopup="T1" rid-ob="ob-T1" co-legend-rid=""><span>Table 1</span></a>), so could not be processed by Auto-CORPus. To overcome this gap in publication table standardization, we are refining a plugin for Auto-CORPus that provides an algorithm for processing images of tables. The algorithm leverages Google's Tesseract optical character recognition engine to extract text from preprocessed table images. An overview of the table image processing pipeline is available in <a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Figure 3</a>. During our preliminary evaluation of the plugin, it achieved an accuracy of ~88% when processing a collection of 200 JPG and PNG table images taken from 23 different journals. Although encouraging, there are caveats in that the image formats must be of high resolution, the algorithm performs better on tables with gridlines than tables without gridlines, special characters are rarely interpreted correctly, and cell text formatting is lost. We are fine tuning the Tesseract model by training new datasets on biomedical data. An alpha release of the table image processing plugin is available with the Auto-CORPus package.</p><p>The authors are involved in omics health data NLP projects that use Auto-CORPus within text mining pipelines to standardize and optimize biomedical literature ahead of entity and relation annotations and have given examples in the <a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Material</a> of how the Auto-CORPus output was used to train these algorithms. The BioC format supports the stand-off annotation of linguistic features such as tokens, part-of-speech tags and noun phrases, as well as the annotation of relations between these elements (<a href="#B5" rid="B5" class=" bibr popnode">5</a>). We are developing machine learning methods to automatically extract genome-wide association study (GWAS) data from peer-reviewed literature. High quality annotated datasets are required to develop and train NLP algorithms and validate the outputs. We are developing a GWAS corpus that can be used for this purpose using a semi-automated annotation method. The GWAS Central database is a comprehensive collection of summary-level GWAS findings imported from published research papers or submitted by study authors (<a href="#B13" rid="B13" class=" bibr popnode">13</a>). For GWAS Central studies, we used Auto-CORPus to standardize the full-text publication text and tables. In an automatic annotation step, for each publication, all GWAS Central association data was retrieved. Association data consists of three related entities: a phenotype/disease description, genetic marker, and an association <em>P</em>-value. A named entity recognition algorithm identifies the database entities in the Auto-CORPus BioC and table JSON files. The database entities and relations are mapped back onto the text, by expressing the annotations in BioC format and appending these to the relevant BioC element in the JSON files. The automatic annotations are then manually evaluated using the TeamTat text annotation tool which provides a user-friendly interface for annotating entities and relations (<a href="#B17" rid="B17" class=" bibr popnode">17</a>). We use TeamTat to manually inspect the automatic annotations and modify or remove incorrect annotations, in addition to including new annotations that were not automatically generated. TeamTat accepts BioC input files and outputs in BioC format, thus the Auto-CORPus files that have been automatically annotated are suitable for importing into TeamTat. Work to create the GWAS corpus is ongoing, but the convenient semi-automatic process for creating high-quality annotations from biomedical literature HTML files described here could be adapted for creating other gold-standard corpora.</p><p class="p p-last">In related work, we are developing a corpus for MWAS for metabolite named-entity recognition to enable the development of new NLP tools to speed up literature review. As part of this, the active development focuses on extending Auto-CORPus to analyse preprint literature and <a href="#SM1" rid="SM1" class=" supplementary-material">Supplementary Materials</a>, improving the abbreviation detection, and development of more configuration files. Our preliminary work on preprint literature has shown we can map paragraphs in Rxiv versions to paragraphs in the peer-reviewed manuscript with the high accuracy (average similarity of paragraphs &#x0003e;95%). Another planned extension is to classify paragraphs based on the text in the case where headers are mapped to multiple IAO terms. The flexibility of the Auto-CORPus configuration file enables researchers to use Auto-CORPus to process publications and data from a broad variety of sources to create reusable corpora for many use cases in biomedical literature and other scientific fields.</p></div></div><div id="s5" class="tsec sec"><h2 class="head no_bottom_margin" id="s5title">Data Availability Statement</h2><p class="p p-first-last">Publicly available datasets were analyzed in this study. The Auto-CORPus package is freely available from GitHub (<a href="https://github.com/omicsNLP/Auto-CORPus" data-ga-action="click_feat_suppl" ref="reftype=extlink&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CBody&amp;TO=External%7CLink%7CURI" target="_blank">https://github.com/omicsNLP/Auto-CORPus</a>) and can be deployed on local machines as well as using high-performance computing to process publications in batch. A step-by-step guide to detail how to use Auto-CORPus is supplied with the package. Data from both Open Access (<em>via</em> PubMed Central) and publisher repositories are used, the latter were downloaded within university library licenses and cannot be shared.</p></div><div id="s6" class="tsec sec"><h2 class="head no_bottom_margin" id="s6title">Author Contributions</h2><p class="p p-first-last">TB and JP designed and supervised the research and wrote the manuscript. TB contributed the GWAS use case and JP contributed the MWAS/metabolomics use cases. TS developed the BioC outputs and led the coding integration aspects. YH developed the section header standardization algorithm and implemented the abbreviation recognition algorithm. ZL developed the table image recognition and processing algorithm. SS developed the table extraction algorithm and main configuration file. CP developed configuration files for preprint texts. NM developed the NER algorithms for GWAS entity recognition. NM, FM, CY, ZL, and CP tested the package and performed comparative analysis of outputs. TR refined standardization of full-texts and contributed algorithms for character set conversions. All authors read, edited, and approved the manuscript.</p></div><div id="s7" class="tsec sec"><h2 class="head no_bottom_margin" id="s7title">Funding</h2><p class="p p-first-last">This work has been supported by Health Data Research (HDR) UK and the Medical Research Council <em>via</em> an UKRI Innovation Fellowship to TB (MR/S003703/1) and a Rutherford Fund Fellowship to JP (MR/S004033/1).</p></div><div id="conf1" class="tsec sec"><h2 class="head no_bottom_margin" id="conf1title">Conflict of Interest</h2><p class="p p-first-last">The authors declare that the research was conducted in the absence of any commercial or financial relationships that could be construed as a potential conflict of interest.</p></div><div id="s8" class="tsec sec"><h2 class="head no_bottom_margin" id="s8title">Publisher's Note</h2><p class="p p-first-last">All claims expressed in this article are solely those of the authors and do not necessarily represent those of their affiliated organizations, or those of the publisher, the editors and the reviewers. Any product that may be evaluated in this article, or claim that may be made by its manufacturer, is not guaranteed or endorsed by the publisher.</p></div><div id="ack-a.t.a" class="tsec sec"><h2 class="head no_bottom_margin" id="ack-a.t.atitle">Acknowledgments</h2><div class="sec"><p>We thank Mohamed Ibrahim (University of Leicester) for identifying different configurations of tables for different HTML formats.</p></div></div><div id="s9" class="tsec bk-sec"><a id="supplementary-material-sec"></a><h2 class="head no_bottom_margin" id="s9title">Supplementary Material</h2><!--/article/back/sec/--><p class="p p-first">The Supplementary Material for this article can be found online at: <a href="https://www.frontiersin.org/articles/10.3389/fdgth.2022.788124/full#supplementary-material" data-ga-action="click_feat_suppl" ref="reftype=extlink&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CBody&amp;TO=External%7CLink%7CURI" target="_blank">https://www.frontiersin.org/articles/10.3389/fdgth.2022.788124/full#supplementary-material</a></p><div class="sec suppmat" id="SM1"><div class="sup-box half_rhythm" id="media-a.t.b.c.a"><a href="/pmc/articles/PMC8885717/bin/Data_Sheet_1.PDF" data-ga-action="click_feat_suppl">Click here for additional data file.</a><sup>(1.8M, PDF)</sup></div></div></div><div id="ref-list-a.t.c" class="tsec sec"><h2 class="head no_bottom_margin" id="ref-list-a.t.ctitle">References</h2><div class="ref-list-sec sec" id="reference-list"><div class="ref-cit-blk half_rhythm" id="B1">1. <span class="mixed-citation">Sheikhalishahi S, Miotto R, Dudley JT, Lavelli A, Rinaldi F, Osmani V. <span class="ref-title">Natural language processing of clinical notes on chronic diseases: systematic review</span>. <span class="ref-journal">JMIR Med Inform.</span> (2019) <span class="ref-vol">7</span>:e12239. 10.2196/12239 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC6528438/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/31066697" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.2196%2F12239" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=JMIR+Med+Inform.&amp;title=Natural+language+processing+of+clinical+notes+on+chronic+diseases:+systematic+review&amp;author=S+Sheikhalishahi&amp;author=R+Miotto&amp;author=JT+Dudley&amp;author=A+Lavelli&amp;author=F+Rinaldi&amp;volume=7&amp;publication_year=2019&amp;pages=e12239&amp;pmid=31066697&amp;doi=10.2196/12239&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B2">2. <span class="mixed-citation">Jackson RG, Patel R, Jayatilleke N, Kolliakou A, Ball M, Gorrell G, et al.. <span class="ref-title">Natural language processing to extract symptoms of severe mental illness from clinical text: the Clinical Record Interactive Search Comprehensive Data Extraction (CRIS-CODE) project</span>. <span class="ref-journal">BMJ Open</span>. (2017) <span class="ref-vol">7</span>:e012012. 10.1136/bmjopen-2016-012012 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC5253558/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/28096249" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1136%2Fbmjopen-2016-012012" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=BMJ+Open&amp;title=Natural+language+processing+to+extract+symptoms+of+severe+mental+illness+from+clinical+text:+the+Clinical+Record+Interactive+Search+Comprehensive+Data+Extraction+(CRIS-CODE)+project&amp;author=RG+Jackson&amp;author=R+Patel&amp;author=N+Jayatilleke&amp;author=A+Kolliakou&amp;author=M+Ball&amp;volume=7&amp;publication_year=2017&amp;pages=e012012&amp;pmid=28096249&amp;doi=10.1136/bmjopen-2016-012012&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B3">3. <span class="mixed-citation">Erhardt RA, Schneider R, Blaschke C. <span class="ref-title">Status of text-mining techniques applied to biomedical text</span>. <span class="ref-journal">Drug Discov Today.</span> (2006) <span class="ref-vol">11</span>:315&#x02013;25. 10.1016/j.drudis.2006.02.011 [<a href="https://pubmed.ncbi.nlm.nih.gov/16580973" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1016%2Fj.drudis.2006.02.011" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Drug+Discov+Today.&amp;title=Status+of+text-mining+techniques+applied+to+biomedical+text&amp;author=RA+Erhardt&amp;author=R+Schneider&amp;author=C+Blaschke&amp;volume=11&amp;publication_year=2006&amp;pages=315-25&amp;pmid=16580973&amp;doi=10.1016/j.drudis.2006.02.011&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B4">4. <span class="mixed-citation">Wang LL, Cachola I, Bragg J, Yu-Yen Cheng E, Haupt C, Latzke M, et al.. <span class="ref-title">Improving the accessibility of scientific documents: current state, user needs, and a system solution to enhance scientific PDF accessibility for blind and low vision users</span>. <span class="ref-journal">arXiv e-prints: arXiv:2105.00076</span> (2021). Available online at: <a href="https://arxiv.org/pdf/2105.00076.pdf" data-ga-action="click_feat_suppl" ref="reftype=extlink&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=External%7CLink%7CURI" target="_blank">https://arxiv.org/pdf/2105.00076.pdf</a></span></div><div class="ref-cit-blk half_rhythm" id="B5">5. <span class="mixed-citation">Comeau DC, Islamaj Dogan R, Ciccarese P, Cohen KB, Krallinger M, Leitner F, et al.. <span class="ref-title">BioC: a minimalist approach to interoperability for biomedical text processing</span>. <span class="ref-journal">Database.</span> (2013) <span class="ref-vol">2013</span>:bat064. 10.1093/database/bat064 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC3889917/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/24048470" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1093%2Fdatabase%2Fbat064" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Database.&amp;title=BioC:+a+minimalist+approach+to+interoperability+for+biomedical+text+processing&amp;author=DC+Comeau&amp;author=R+Islamaj+Dogan&amp;author=P+Ciccarese&amp;author=KB+Cohen&amp;author=M+Krallinger&amp;volume=2013&amp;publication_year=2013&amp;pages=bat064&amp;pmid=24048470&amp;doi=10.1093/database/bat064&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B6">6. <span class="mixed-citation">Comeau DC, Wei CH, Islamaj Dogan R, Lu Z. <span class="ref-title">PMC text mining subset in BioC: about three million full-text articles and growing</span>. <span class="ref-journal">Bioinformatics.</span> (2019) <span class="ref-vol">35</span>:3533&#x02013;5. 10.1093/bioinformatics/btz070 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC6748740/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/30715220" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1093%2Fbioinformatics%2Fbtz070" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Bioinformatics.&amp;title=PMC+text+mining+subset+in+BioC:+about+three+million+full-text+articles+and+growing&amp;author=DC+Comeau&amp;author=CH+Wei&amp;author=R+Islamaj+Dogan&amp;author=Z+Lu&amp;volume=35&amp;publication_year=2019&amp;pages=3533-5&amp;pmid=30715220&amp;doi=10.1093/bioinformatics/btz070&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B7">7. <span class="mixed-citation">Ceusters W. <span class="ref-title">An information artifact ontology perspective on data collections and associated representational artifacts</span>. <span class="ref-journal">Stud Health Technol Inform.</span> (2012) <span class="ref-vol">180</span>:68&#x02013;72. 10.3233/978-1-61499-101-4-68 [<a href="https://pubmed.ncbi.nlm.nih.gov/22874154" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.3233%2F978-1-61499-101-4-68" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Stud+Health+Technol+Inform.&amp;title=An+information+artifact+ontology+perspective+on+data+collections+and+associated+representational+artifacts&amp;author=W+Ceusters&amp;volume=180&amp;publication_year=2012&amp;pages=68-72&amp;pmid=22874154&amp;doi=10.3233/978-1-61499-101-4-68&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B8">8. <span class="mixed-citation">Milosevic N, Gregson C, Hernandez R, Nenadic G. <span class="ref-title">Disentangling the structure of tables in scientific literature</span>. In: M&#x000e9;tais E, Meziane F, Saraee M, Sugumaran V, Vadera S, editors. <span class="ref-journal">Natural Language Processing and Information Systems</span>. Cham: Springer International Publishing;  (2016). p. 162&#x02013;74. 10.1007/978-3-319-41754-7_14 [<a href="//doi.org/10.1007%2F978-3-319-41754-7_14" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?title=Natural+Language+Processing+and+Information+Systems&amp;author=N+Milosevic&amp;author=C+Gregson&amp;author=R+Hernandez&amp;author=G+Nenadic&amp;publication_year=2016&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B9">9. <span class="mixed-citation">Craven M, Kumlien J. <span class="ref-title">Constructing biological knowledge bases by extracting information from text sources</span>. In: <span class="ref-journal">International Conference on Intelligent Systems for Molecular Biology.</span>
 Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov/10786289" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?title=International+Conference+on+Intelligent+Systems+for+Molecular+Biology.&amp;author=M+Craven&amp;author=J+Kumlien&amp;publication_year=1999&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B10">10. <span class="mixed-citation">Blaschke C, Andrade MA, Ouzounis C, Valencia A. <span class="ref-title">Automatic extraction of biological information from scientific text: protein-protein interactions</span>. In: <span class="ref-journal">International Conference on Intelligent Systems for Molecular Biology</span>. Heidelberg:  (1999) p. 60&#x02013;7.  [<a href="https://pubmed.ncbi.nlm.nih.gov/10786287" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?title=International+Conference+on+Intelligent+Systems+for+Molecular+Biology&amp;author=C+Blaschke&amp;author=MA+Andrade&amp;author=C+Ouzounis&amp;author=A+Valencia&amp;publication_year=1999&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B11">11. <span class="mixed-citation">Andrade MA, Valencia A. <span class="ref-title">Automatic annotation for biological sequences by extraction of keywords from MEDLINE abstracts. Development of a prototype system</span>. <span class="ref-journal">Proc Int Conf Intell Syst Mol Biol.</span> (1997) <span class="ref-vol">5</span>:25&#x02013;32.  [<a href="https://pubmed.ncbi.nlm.nih.gov/9322011" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Proc+Int+Conf+Intell+Syst+Mol+Biol.&amp;title=Automatic+annotation+for+biological+sequences+by+extraction+of+keywords+from+MEDLINE+abstracts.+Development+of+a+prototype+system&amp;author=MA+Andrade&amp;author=A+Valencia&amp;volume=5&amp;publication_year=1997&amp;pages=25-32&amp;pmid=9322011&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B12">12. <span class="mixed-citation">Schwartz AS, Hearst MA. <span class="ref-title">A simple algorithm for identifying abbreviation definitions in biomedical text</span>. <span class="ref-journal">Pac Symp Biocomput.</span> (2003) <span class="ref-vol">8</span>:451&#x02013;62. Available online at: <a href="https://psb.stanford.edu/psb-online/proceedings/psb03/schwartz.pdf" data-ga-action="click_feat_suppl" ref="reftype=extlink&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=External%7CLink%7CURI" target="_blank">https://psb.stanford.edu/psb-online/proceedings/psb03/schwartz.pdf</a> [<a href="https://pubmed.ncbi.nlm.nih.gov/12603049" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Pac+Symp+Biocomput.&amp;title=A+simple+algorithm+for+identifying+abbreviation+definitions+in+biomedical+text&amp;author=AS+Schwartz&amp;author=MA+Hearst&amp;volume=8&amp;publication_year=2003&amp;pages=451-62&amp;pmid=12603049&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B13">13. <span class="mixed-citation">Beck T, Shorter T, Brookes AJ. <span class="ref-title">GWAS Central: a comprehensive resource for the discovery and comparison of genotype and phenotype data from genome-wide association studies</span>. <span class="ref-journal">Nucleic Acids Res</span>. (2020) <span class="ref-vol">48</span>:D933&#x02013;40. 10.1093/nar/gkz895 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC7145571/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/31612961" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1093%2Fnar%2Fgkz895" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Nucleic+Acids+Res&amp;title=GWAS+Central:+a+comprehensive+resource+for+the+discovery+and+comparison+of+genotype+and+phenotype+data+from+genome-wide+association+studies&amp;author=T+Beck&amp;author=T+Shorter&amp;author=AJ+Brookes&amp;volume=48&amp;publication_year=2020&amp;pages=D933-40&amp;pmid=31612961&amp;doi=10.1093/nar/gkz895&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B14">14. <span class="mixed-citation">Ghazvinian A, Noy NF, Musen MA. <span class="ref-title">Creating mappings for ontologies in biomedicine: simple methods work</span>. <span class="ref-journal">AMIA Annu Symp Proc.</span> (2009) <span class="ref-vol">2009</span>:198&#x02013;202.  <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC2815474/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/20351849" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=AMIA+Annu+Symp+Proc.&amp;title=Creating+mappings+for+ontologies+in+biomedicine:+simple+methods+work&amp;author=A+Ghazvinian&amp;author=NF+Noy&amp;author=MA+Musen&amp;volume=2009&amp;publication_year=2009&amp;pages=198-202&amp;pmid=20351849&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B15">15. <span class="mixed-citation">Keller MF, Reiner AP, Okada Y, van Rooij FJ, Johnson AD, Chen MH, et al.. <span class="ref-title">Trans-ethnic meta-analysis of white blood cell phenotypes</span>. <span class="ref-journal">Hum Mol Genet.</span> (2014) <span class="ref-vol">23</span>:6944&#x02013;60. 10.1093/hmg/ddu401 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC4245044/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/25096241" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1093%2Fhmg%2Fddu401" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Hum+Mol+Genet.&amp;title=Trans-ethnic+meta-analysis+of+white+blood+cell+phenotypes&amp;author=MF+Keller&amp;author=AP+Reiner&amp;author=Y+Okada&amp;author=FJ+van+Rooij&amp;author=AD+Johnson&amp;volume=23&amp;publication_year=2014&amp;pages=6944-60&amp;pmid=25096241&amp;doi=10.1093/hmg/ddu401&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B16">16. <span class="mixed-citation">Milosevic N, Gregson C, Hernandez R, Nenadic G. <span class="ref-title">A framework for information extraction from tables in biomedical literature</span>. <span class="ref-journal">Int J Docum Anal Recogn.</span> (2019) <span class="ref-vol">22</span>:55&#x02013;78. 10.1007/s10032-019-00317-0 [<a href="//doi.org/10.1007%2Fs10032-019-00317-0" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Int+J+Docum+Anal+Recogn.&amp;title=A+framework+for+information+extraction+from+tables+in+biomedical+literature&amp;author=N+Milosevic&amp;author=C+Gregson&amp;author=R+Hernandez&amp;author=G+Nenadic&amp;volume=22&amp;publication_year=2019&amp;pages=55-78&amp;pmid=23869631&amp;doi=10.1007/s10032-019-00317-0&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div><div class="ref-cit-blk half_rhythm" id="B17">17. <span class="mixed-citation">Islamaj R, Kwon D, Kim S, Lu Z. <span class="ref-title">TeamTat: a collaborative text annotation tool</span>. <span class="ref-journal">Nucleic Acids Res</span>. (2020) <span class="ref-vol">48</span>:W5&#x02013;11. 10.1093/nar/gkaa333 <span class="nowrap">[<a class="int-reflink" href="/pmc/articles/PMC7319445/">PMC free article</a>]</span> [<a href="https://pubmed.ncbi.nlm.nih.gov/32383756" ref="reftype=pubmed&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Entrez%7CPubMed%7CRecord">PubMed</a>] [<a href="//doi.org/10.1093%2Fnar%2Fgkaa333" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CCrosslink%7CDOI">CrossRef</a>] <span class="nowrap">[<a href="https://scholar.google.com/scholar_lookup?journal=Nucleic+Acids+Res&amp;title=TeamTat:+a+collaborative+text+annotation+tool&amp;author=R+Islamaj&amp;author=D+Kwon&amp;author=S+Kim&amp;author=Z+Lu&amp;volume=48&amp;publication_year=2020&amp;pages=W5-11&amp;pmid=32383756&amp;doi=10.1093/nar/gkaa333&amp;" target="_blank" rel="noopener noreferrer" ref="reftype=other&amp;article-id=8885717&amp;issue-id=400615&amp;journal-id=4104&amp;FROM=Article%7CCitationRef&amp;TO=Content%20Provider%7CLink%7CGoogle%20Scholar">Google Scholar</a>]</span></span></div></div></div></div><!--post-content--><div class="courtesy-note whole_rhythm small"><hr /><div class="half_rhythm">Articles from <span class="acknowledgment-journal-title">Frontiers in Digital Health</span> are provided here courtesy of <strong>Frontiers Media SA</strong></div><hr /></div><div id="body-link-poppers"><span></span></div></div>
-
+            
         </section>
     </article>
     <aside class="usa-width-one-fourth usa-layout-docs-sidenav pmc-sidebar">
-
-
+         
+  
 
 <div class="scroller">
 
-
+    
         <section>
                 <h6>Other Formats</h6>
                 <ul class="pmc-sidebar__formats">
                   <li class="pdf-link other_item"><a href="/pmc/articles/PMC8885717/pdf/fdgth-04-788124.pdf" class="int-view">PDF (2.7M)</a></li>
                 </ul>
         </section>
-
+    
     <section>
         <h6>Actions</h6>
         <ul class="pmc-sidebar__actions">
@@ -786,8 +786,8 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
                 </button>
             </li>
             <li>
-
-
+                
+                    
 
 <link type="text/css" href="ncbi-overlay-block/src/overlay-block.css">
 <div class="collections-button-container" data-article-id="8885717" data-article-db="pmc">
@@ -807,7 +807,7 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
        aria-hidden="true">
     <div class="title">Add to Collections</div>
     <div class="collections-action-panel action-panel">
-
+      
 
 
 <form id="collections-action-dialog-form"
@@ -820,7 +820,7 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
 
   <input type="hidden" name="csrfmiddlewaretoken" value="lyoBdak3TySdV2Pk7demx2dF10auTwlTzOqnaZr8odGkmGXu8bNK8X8OAWVrnOzk">
 
-
+  
 
   <div class="choice-group" role="radiogroup">
     <ul class="radio-group-items">
@@ -912,16 +912,16 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
   </div>
 </div>
 </div>
-
+                
             </li>
 
         </ul>
     </section>
-
+    
         <section class="social-sharing">
             <h6>Share</h6>
             <ul class="pmc-sidebar__share">
-                <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F&amp;text=Auto-CORPus%3A%20A%20Natural%20Language%20Processing%20Tool%20for%20Standardizing%20and%20Reusing%20Biomedical%20Literature" alt="Share on Twitter"><i class="fa fa-twitter fa-stack-1x">&#160;</i></a></li>
+                <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://twitter.com/intent/tweet?url=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F&amp;text=Auto-CORPus%3A%20A%20Natural%20Language%20Processing%20Tool%20for%20Standardizing%20and%20Reusing%20Biomedical%20Literature" alt="Share on Twitter"><i class="fa fa-twitter fa-stack-1x">&#160;</i></a></li> 
 <li><a class="fa-stack fa-lg" target="_blank" rel="noopener noreferrer" role="button" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fwww.ncbi.nlm.nih.gov%2Fpmc%2Farticles%2FPMC8885717%2F" alt="Share on Facebook"><i class="fa fa-facebook fa-stack-1x">&#160;</i></a></li>
                 <li>
                     <div class="share-permalink">
@@ -944,11 +944,11 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
                 </li>
             </ul>
         </section>
-
+    
     <section>
         <h6>RESOURCES</h6>
         <ul class="pmc-sidebar__resources">
-
+        
             <li>
                 <div class="usa-accordion">
                     <button
@@ -964,12 +964,12 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
                         Similar articles
                     </button>
                     <div
-
+                            
                                 data-source-url="/pmc/resources/similar-article-links/35243479/"
-
+                            
 
                          class="usa-accordion-content pmc-sidebar__resources--citations" id="similar-articles-accordion-aside" aria-hidden="true">
-
+                        
                     </div>
                 </div>
             </li>
@@ -988,14 +988,14 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
                         Cited by other articles
                     </button>
                     <div
-
+                            
                                 data-source-url="/pmc/resources/cited-by-links/35243479/"
-
+                            
                             class="usa-accordion-content pmc-sidebar__resources--citations"
                             id="cited-by-accordion-aside"
                             aria-hidden="true"
                     >
-
+                        
                     </div>
                 </div>
             </li>
@@ -1017,8 +1017,8 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
                 </div>
             </li>
 
-
-
+            
+        
         </ul>
     </section>
 
@@ -1055,36 +1055,36 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
       </a>
 
 
-
+    
 
 <div class="citation-style-selector-wrapper">
   <label class="selector-label">Format:</label>
   <select aria-label="Format" class="citation-style-selector" tabindex="4" >
-
+    
       <option data-style-url-name="ama"
               value="AMA"
               >
         AMA
       </option>
-
+    
       <option data-style-url-name="apa"
               value="APA"
               >
         APA
       </option>
-
+    
       <option data-style-url-name="mla"
               value="MLA"
               >
         MLA
       </option>
-
+    
       <option data-style-url-name="nlm"
               value="NLM"
               selected="selected">
         NLM
       </option>
-
+    
   </select>
 </div>
   </div>
@@ -1305,7 +1305,7 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
     </footer>
  <!-- ========== END FOOTER ========== -->
   <!-- javascript to inject NWDS meta tags. Note: value of nwds_version is updated by "npm version" command -->
-
+ 
   <script type="text/javascript">
     var nwds_version = "1.1.9-2";
 
@@ -1327,11 +1327,11 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
 
 
 
-
+  
     <!-- JavaScript -->
     <script src="/pmc/static/CACHE/js/output.0f72d6a64937.js"></script>
-
-
+  
+  
     <script src="https://code.jquery.com/jquery-3.5.0.min.js"
           integrity="sha256-xNzN2a4ltkB44Mc/Jz3pT4iU1cmeR0FkXs4pru/JxaQ="
           crossorigin="anonymous">
@@ -1340,7 +1340,7 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
         var fallbackJquery = "/pmc/static/base/js/jquery-3.5.0.min.js";
         window.jQuery || document.write("<script src=" + fallbackJquery + ">\x3C/script>")
     </script>
-
+  
 
   <script src="/pmc/static/CACHE/js/output.a212a9fcf845.js"></script>
 <script src="/pmc/static/CACHE/js/output.7999321d1aac.js"></script>
@@ -1368,14 +1368,14 @@ Heidelberg:  (1999) p. 77&#x02013;86.  [<a href="https://pubmed.ncbi.nlm.nih.gov
     </script>
 
 
-
-
+  
+  
   <script  type="text/javascript" src="https://www.ncbi.nlm.nih.gov/core/pinger/pinger.js"> </script>
 
 
-
-
-
+  
+      
+  
 
 </body>
 </html>

--- a/tests/data/PMC8885717_abbreviations.json
+++ b/tests/data/PMC8885717_abbreviations.json
@@ -1,68 +1,68 @@
 {
-    "source": "Auto-CORPus (abbreviations)",
-    "date": "20240829",
-    "key": "autocorpus_abbreviations.key",
-    "documents": [
+  "source": "Auto-CORPus (abbreviations)",
+  "date": "20240829",
+  "key": "autocorpus_abbreviations.key",
+  "documents": [
+    {
+      "id": "PMC8885717",
+      "inputfile": "tests/data/PMC8885717.html",
+      "passages": [
         {
-            "id": "PMC8885717",
-            "inputfile": "tests/data/PMC8885717.html",
-            "passages": [
-                {
-                    "text_short": "NLP",
-                    "text_long_1": "Natural language processing",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "PMC",
-                    "text_long_1": "PubMed Central",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "IAO",
-                    "text_long_1": "Information Artifact Ontology",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "GWAS",
-                    "text_long_1": "genome-wide association study",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "MWAS",
-                    "text_long_1": "Metabolome-Wide Association Study",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "OA",
-                    "text_long_1": "Open Access",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "DPGs",
-                    "text_long_1": "directed path graphs",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "LOOM",
-                    "text_long_1": "Lexical OWL Ontology Matcher",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "NER",
-                    "text_long_1": "named-entity recognition",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "HDR",
-                    "text_long_1": "Health Data Research",
-                    "extraction_algorithm_1": "fulltext"
-                },
-                {
-                    "text_short": "CRIS-CODE",
-                    "text_long_1": "Clinical Record Interactive Search Comprehensive Data Extraction",
-                    "extraction_algorithm_1": "fulltext"
-                }
-            ]
+          "text_short": "NLP",
+          "text_long_1": "Natural language processing",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "PMC",
+          "text_long_1": "PubMed Central",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "IAO",
+          "text_long_1": "Information Artifact Ontology",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "GWAS",
+          "text_long_1": "genome-wide association study",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "MWAS",
+          "text_long_1": "Metabolome-Wide Association Study",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "OA",
+          "text_long_1": "Open Access",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "DPGs",
+          "text_long_1": "directed path graphs",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "LOOM",
+          "text_long_1": "Lexical OWL Ontology Matcher",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "NER",
+          "text_long_1": "named-entity recognition",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "HDR",
+          "text_long_1": "Health Data Research",
+          "extraction_algorithm_1": "fulltext"
+        },
+        {
+          "text_short": "CRIS-CODE",
+          "text_long_1": "Clinical Record Interactive Search Comprehensive Data Extraction",
+          "extraction_algorithm_1": "fulltext"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tests/data/PMC8885717_bioc.json
+++ b/tests/data/PMC8885717_bioc.json
@@ -1,835 +1,835 @@
 {
-    "source": "Auto-CORPus (full-text)",
-    "date": "20240829",
-    "key": "autocorpus_fulltext.key",
-    "infons": {},
-    "documents": [
+  "source": "Auto-CORPus (full-text)",
+  "date": "20240829",
+  "key": "autocorpus_fulltext.key",
+  "infons": {},
+  "documents": [
+    {
+      "id": "PMC8885717",
+      "inputfile": "tests/data/PMC8885717.html",
+      "infons": {},
+      "passages": [
         {
-            "id": "PMC8885717",
-            "inputfile": "tests/data/PMC8885717.html",
-            "infons": {},
-            "passages": [
-                {
-                    "offset": 0,
-                    "infons": {
-                        "iao_name_1": "document title",
-                        "iao_id_1": "IAO:0000305"
-                    },
-                    "text": "Auto-CORPus: A Natural Language Processing Tool for Standardizing and Reusing Biomedical Literature",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 99,
-                    "infons": {
-                        "section_title_1": "keywords",
-                        "iao_name_1": "keywords section",
-                        "iao_id_1": "IAO:0000630"
-                    },
-                    "text": "natural language processing, text mining, biomedical literature, semantics, health data",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 194,
-                    "infons": {
-                        "section_title_1": "document part",
-                        "iao_name_1": "document part",
-                        "iao_id_1": "IAO:0000314"
-                    },
-                    "text": "Publicly available datasets were analyzed in this study. The Auto-CORPus package is freely available from GitHub (https://github.com/omicsNLP/Auto-CORPus) and can be deployed on local machines as well as using high-performance computing to process publications in batch. A step-by-step guide to detail how to use Auto-CORPus is supplied with the package. Data from both Open Access (via PubMed Central) and publisher repositories are used, the latter were downloaded within university library licenses and cannot be shared.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 730,
-                    "infons": {
-                        "section_title_1": "Abstract",
-                        "iao_name_1": "textual abstract section",
-                        "iao_id_1": "IAO:0000315"
-                    },
-                    "text": "To analyse large corpora using machine learning and other Natural Language Processing (NLP) algorithms, the corpora need to be standardized. The BioC format is a community-driven simple data structure for sharing text and annotations, however there is limited access to biomedical literature in BioC format and a lack of bioinformatics tools to convert online publication HTML formats to BioC. We present Auto-CORPus (Automated pipeline for Consistent Outputs from Research Publications), a novel NLP tool for the standardization and conversion of publication HTML and table image files to three convenient machine-interpretable outputs to support biomedical text analytics. Firstly, Auto-CORPus can be configured to convert HTML from various publication sources to BioC. To standardize the description of heterogenous publication sections, the Information Artifact Ontology is used to annotate each section within the BioC output. Secondly, Auto-CORPus transforms publication tables to a JSON format to store, exchange and annotate table data between text analytics systems. The BioC specification does not include a data structure for representing publication table data, so we present a JSON format for sharing table content and metadata. Inline tables within full-text HTML files and linked tables within separate HTML files are processed and converted to machine-interpretable table JSON format. Finally, Auto-CORPus extracts abbreviations declared within publication text and provides an abbreviations JSON output that relates an abbreviation with the full definition. This abbreviation collection supports text mining tasks such as named entity recognition by including abbreviations unique to individual publications that are not contained within standard bio-ontologies and dictionaries. The Auto-CORPus package is freely available with detailed instructions from GitHub at: https://github.com/omicsNLP/Auto-CORPus.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 2662,
-                    "infons": {
-                        "section_title_1": "Introduction",
-                        "iao_name_1": "introduction section",
-                        "iao_id_1": "IAO:0000316"
-                    },
-                    "text": "Natural language processing (NLP) is a branch of artificial intelligence that uses computers to process, understand, and use human language. NLP is applied in many different fields including language modeling, speech recognition, text mining, and translation systems. In the biomedical realm NLP has been applied to extract, for example, medication data from electronic health records and patient clinical history from free-text (unstructured) clinical notes, to significantly speed up processes that would otherwise be extracted manually by experts (1, 2). Biomedical research publications, although semi-structured, pose similar challenges with regards to extracting and integrating relevant information (3). The full-text of biomedical literature is predominately made available online in the accessible and reusable HTML format, however, some publications are only available as PDF documents which are more difficult to reuse. Efforts to resolve the problem of publication text accessibility across science in general includes work by the Semantic Scholar search engine to convert PDF documents to HTML formats (4). Whichever process is used to obtain a suitable HTML file, before the text can be processed using NLP, heterogeneously structured HTML requires standardization and optimization. BioC is a simple JSON (and XML) format for sharing and reusing text data that has been developed by the text mining community to improve system interoperability (5). The BioC data model consists of collections of documents divided into data elements such as publication sections and associated entity and relation annotations. PubMed Central (PMC) makes full-text articles from its Open Access and Author Manuscript collections available in BioC format (6). To our knowledge there are no services available to convert PMC publications that are not part of these collections to BioC. Additionally, there is a gap in available software to convert publishers' publication HTML to BioC, creating a bottleneck in many biomedical literature text mining workflows caused by having to process documents in heterogenous formats. To bridge this gap, we have developed an Automated pipeline for Consistent Outputs from Research Publications (Auto-CORPus) that can be configured to process any HTML publication structure and transform the corresponding publications to BioC format.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 5040,
-                    "infons": {
-                        "section_title_1": "Introduction",
-                        "iao_name_1": "introduction section",
-                        "iao_id_1": "IAO:0000316"
-                    },
-                    "text": "During information extraction, the publication section context of an entity will assist with entity prioritization. For example, an entity identified in the Results Section may be regarded as a higher priority novel finding than one identified in the Introduction Section. However, the naming and the sequential order of sections within research articles differ between publications. A Methods section, for example, may be found at different locations relative to other sections and identified using a range of synonyms such as experimental section, experimental procedures, and methodology. The Information Artifact Ontology (IAO) was created to serve as a domain-neutral resource for the representation of types of information content entities such as documents, databases, and digital images (7). Auto-CORPus applies IAO annotations to BioC file outputs to standardize the description of sections across all processed publications.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 5974,
-                    "infons": {
-                        "section_title_1": "Introduction",
-                        "iao_name_1": "introduction section",
-                        "iao_id_1": "IAO:0000316"
-                    },
-                    "text": "Vast amounts of biomedical data are contained in publication tables which can be large and multi-dimensional where information beyond a standard two-dimensional matrix is conveyed to a human reader. For example, a table may have subsections or entirely new column headers to merge multiple tables into a single structure. Milosevic and colleagues developed a methodology to analyse complex tables that are represented in XML format and perform a semantic analysis to classify the data types used within a table (8). The outputs from the table analysis are stored in esoteric XML or database models. The communal BioC format on the other hand has limited support for tables, for example the PMC BioC JSON output includes table data in PMC XML format, introducing file parsing complexity. In addition to variations in how tables are structured, there is variability amongst table filetypes. Whereas, publication full-text is contained within a single HTML file, tables may be contained within that full-text file (inline tables), or individual tables may be contained in separate HTML files (linked tables). We have defined a dedicated table JSON format for representing table data from both formats of table. The contents of individual cells are unambiguously identified and thus can be used in entity and relation annotations. In developing the Auto-CORPus table JSON format, we adopted a similar goal to the BioC community, namely, a simple format to maximize interoperability and reuse of table documents and annotations. The table JSON reuses the BioC data model for entity and relation annotations, ensuring that table and full-text annotations can share the same BioC syntax. Auto-CORPus transforms both inline and linked HTML tables to the machine interpretable table JSON format.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 7760,
-                    "infons": {
-                        "section_title_1": "Introduction",
-                        "iao_name_1": "introduction section",
-                        "iao_id_1": "IAO:0000316"
-                    },
-                    "text": "Abbreviations and acronyms are widely used in publication text to reduce space and avoid prolix. Abbreviations and their definitions are useful in text mining to identify lexical variations of words describing identical entities. However, the frequent use of novel abbreviations in texts presents a challenge for the curators of biomedical lexical ontologies to ensure they are continually updated. Several algorithms have been developed to extract abbreviations and their definitions from biomedical text (9\u201311). Abbreviations within publications can be defined when they are declared within the full-text, and in some publications, are included in a dedicated abbreviations section. Auto-CORPus adapts an abbreviation detecting methodology (12) and couples it with IAO section detection to comprehensively extract abbreviations declared in the full-text and in the abbreviations section. For each publication, Auto-CORPus generates an abbreviations dictionary JSON file.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 8732,
-                    "infons": {
-                        "section_title_1": "Introduction",
-                        "iao_name_1": "introduction section",
-                        "iao_id_1": "IAO:0000316"
-                    },
-                    "text": "The aim of this article is to describe the open Auto-CORPus python package and the text mining use cases that make it a simple user-friendly application to create machine interpretable biomedical literature files, from a single publication to a large corpus. The authors share the common interest of progressing text mining capabilities across the biomedical literature domain and contribute omics and health data use cases related to their expertise in Genome-Wide Association Study (GWAS) and Metabolome-Wide Association Study (MWAS) data integration and analytics (see Author Contributions Section). The following sections describe the technical details about the algorithms developed and the benchmarking undertaken to assess the quality of the three Auto-CORPus outputs generated for each publication: BioC full-text, Auto-CORPus tables, and Auto-CORPus abbreviations JSON files.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 9616,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Data for Algorithm Development",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "We used a set of 3,279 full-text HTML and 1,041 linked table files to develop and test the algorithms described in this section. Files for 1,200 Open Access (OA) GWAS publications whose data exists in the GWAS Central database (13) were downloaded from PMC in March 2020. A further 1,241 OA PMC publications of MWAS and metabolomics studies on cancer, gastrointestinal diseases, metabolic syndrome, sepsis and neurodegenerative, psychiatric, and brain illnesses were also downloaded to ensure the methods are not biased toward one domain, more information is available in the Supplementary Material. This formed a collection of 2,441 publications that will be referred to as the \u201cOA dataset.\u201d We also downloaded publisher-specific full-text files, and linked table data were available, for publications whose data exists in the GWAS Central database. This collection of 838 full-text and 1,041 table HTML files will be referred to as the \u201cpublisher dataset.\u201d Table 1 lists the publishers and journals included in the publisher dataset and the number of publications that overlap with the OA dataset. This also includes publications from non-biomedical fields to evaluate the application in other domains.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 10871,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Algorithms for Processing Publication Full-Text HTML",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "An Auto-CORPus configuration file is set by the user to define the heading and paragraph HTML elements used in the publication files to be processed. Regular expressions can be used within the configuration file allowing a group of publications with a similar but not an identical structure to be defined by a single configuration file, for example when processing publications from journals by the same publisher. The heading elements are used to delineate the content of the publication sections and the BioC data structure is populated with publication text. All HTML tags including text formatting (e.g., emphasized words, superscript, and subscript) are removed from the publication text. Each section is automatically annotated using IAO (see Section Algorithms for Classifying Publication Sections With IAO Terms) and the BioC data structure is output in JSON format. The BioC specification requires \u201ckey files\u201d to accompany BioC data files to specify how the data files should be interpreted (5). We provide key files to define the data elements in the Auto-CORPus JSON output files for full-text, tables, and abbreviations (https://github.com/omicsNLP/Auto-CORPus/tree/main/keyFiles). Figure 1 gives an example of the BioC JSON output and the abbreviations and tables outputs are described below.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 12228,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Algorithms for Processing Publication Full-Text HTML",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "Abbreviations in the full-text are found using an adaptation of a previously published methodology and implementation (12). The method finds all brackets within a publication and if there are two or more non-digit characters within brackets it considers if the string in the brackets could be an abbreviation. It searches for the characters present in the brackets in the text on either side of the brackets one by one. The first character of one of these words must contain the first character within the bracket, and the other characters within that bracket must be contained by other words that follow the first word whose first character is the same as the first character in that bracket. An example of the Auto-CORPus abbreviations JSON is given in Figure 2 which shows that the output from this algorithm is stored along with the abbreviations defined in the publication abbreviations section (if present).",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 13141,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Algorithms for Classifying Publication Sections With IAO Terms",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "A total of 21,849 section headers were extracted from the OA dataset and directed path graphs (DPGs) were created for each publication (Figure 3). DPGs are a linear chain without any cycles. For example, at this point in this article the main headers are abstract (one paragraph) followed by introduction (five paragraphs) and materials and methods (four paragraphs, three sub-headers)\u2014this would make up a DPG with three nodes (abstract, introduction, materials and methods) and two directed edges. For our Introduction Section, while the individual five paragraphs within a section would all be mapped to the main header (introduction), only one node would appear in the DPG (relating to the header itself) without any self-edges. The individual DPGs were then combined into a directed graph (digraph, Supplementary Figure 2) and the extracted section headers were mapped to IAO (v2020-06-10) document part terms using the Lexical OWL Ontology Matcher (LOOM) method (14). Fuzzy matching using the fuzzywuzzy python package (v0.17.0) was then used to map headers to the preferred section header terms and synonyms, with a similarity threshold of 0.8 (e.g., the typographical error \u201cexperemintal section\u201d in PMC4286171 is correctly mapped to methods section). This threshold was evaluated by two independent researchers who confirmed all matches for the OA dataset were accurate. Digraphs consist of nodes (entities, headers) and edges (links between nodes) and the weight of the nodes and edges is proportional to the number of publications in which these are found. Here the digraph consists of 372 unique nodes and 806 directed edges (Supplementary Figure 1).",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 14865,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Algorithms for Classifying Publication Sections With IAO Terms",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "However, after direct IAO mapping and fuzzy matching, unmapped headers still existed. To map these headings, we developed a new method using both the digraph and the individual DPGs. The headers are not repeated within a document/DPG, they are sequential/a chain and have a set order that can be exploited. Unmapped headers are assigned a section based on the digraph and the headers in the publication (DPG) that could be mapped (anchor headers), an example is given in Supplementary Figure 2 where a header cannot be mapped to IAO terms. Any unmapped header that is mapped to an existing IAO term in this manner does not result in a self-edge in the network as subsequent repeated headers are collapsed into a single node. Auto-CORPus uses the LOOM, fuzzy matching and digraph prediction algorithms to annotate publication sections with IAO terms in the BioC full-text file. Paragraphs can be mapped to multiple IAO terms in case of publications without main-text headers (based on digraph prediction) or with ambiguous headers (based on fuzzy matching and/or digraph prediction).",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 15947,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "New IAO Terms and Synonyms ",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "We used the IAO classification algorithms to identify potential new IAO terms and synonyms. Three hundred and forty-eight headings from the OA dataset were mapped to IAO terms during the fuzzy matching or mapped based on the digraph using the publication structure and anchor headers. These headings were considered for inclusion in IAO as term synonyms. We manually evaluated each heading and Table 2 lists the 94 synonyms we identified for existing IAO terms.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 16435,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "New IAO Terms and Synonyms ",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "Diagraph nodes that were not mapped to IAO terms but formed heavily weighted \u201cego-networks,\u201d indicating the same heading was found in many publications, were manually evaluated for inclusion in IAO as new terms. For example, based on the digraph, we assigned data and data description to be synonyms of the materials section. The same process was applied to ego-networks from other nodes linked to existing IAO terms to add additional synonyms to simplify the digraph. Figure 4 shows the ego-network for abstract, and four main categories and one potential new synonym (precis, in red) were identified. From the further analysis of all ego-networks, four new potential terms were identified: disclosure, graphical abstract, highlights, and participants\u2014the latter is related to, but deemed distinct from, the existing patients section (IAO:0000635). Table 3 details the proposed definition and synonyms for these terms. The terms and synonyms described here will be submitted to the IAO, with our initial submission of one term and 59 synonyms accepted and included in IAO previously (v2020-12-09) (https://github.com/information-artifact-ontology/IAO/issues/234). Figure 5 shows the resulting digraph with only existing and newly proposed section terms. A major unmapped node is associated data, which is a header specific for PMC articles that appears at the beginning of each article before the abstract. In addition, IAO has separate definitions for materials (IAO:0000633), methods (IAO:0000317), and statistical methods (IAO:0000644) sections, hence they are separate nodes in the graph. The introduction is often followed by these headers to reflect the methods section (and synonyms), however there is also a major directed edge from introduction directly to results to account for materials and methods placed after the discussion and/or conclusion sections in some publications.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 18323,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Auto-CORPus Table JSON Design ",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "The BioC format does not specify how table content should be structured, leaving this open to the interpretation of implementers. For example, the PMC BioC JSON output describes table content using PMC XML (see the \u201cpmc.key\u201d file at https://ftp.ncbi.nlm.nih.gov/pub/wilbur/BioC-PMC/pmc.key). Including markup language within JSON objects presents data parsing challenges and interoperability barriers with non-PMC table data representations. We developed a simple table JSON format that is agnostic to the publication table source, can store multi-dimensional table content from complex table structures, and applies BioC design principles (5) to enable the annotation of entities and relations between entities. The table JSON stores table metadata of title, caption and footer. The table content is stored as \u201ccolumn headers\u201d and \u201cdata rows.\u201d The format supports the use of IAO to define the table metadata and content sections, however additional IAO terms are required to define table metadata document parts. Table 3 includes the proposed definition and synonyms for these terms. To compensate for currently absent IAO terms, we have defined three section type labels: table title, table caption and table footer. To support the text mining of tables, each column header and data row cell has an identifier that can be used to identify entities in annotations. Tables can be arranged into subsections, thus the table JSON represents this and includes subsection headings. Figure 6 gives an example of table metadata and content stored in the Auto-CORPus table JSON format. In addition to the Auto-CORPus key files, we make a table JSON schema available for the validation of table JSON files and to facilitate the use of the format in text analytics software and pipelines.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 20131,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Processing Table HTML ",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "Tables can used within HTML documents for formatting web page layouts and are distinct from the data tables processed by Auto-CORPus. The configuration file set by the user identifies the HTML elements used to define data table containers, which include title, caption, footer, and table content. The files processed can either be a full-text HTML file for inline tables and/or separate HTML files for individual linked tables. The Auto-CORPus algorithm for processing tables is based on the functional and structural table analysis method described by Milosevic et al. (8). The cells that contain navigational information such as column headers and section headings are identified. If a column has header strings contained in cells spanning multiple rows, the strings are concatenated with a pipe character separator to form a single column header string. The \u201csuper row\u201d is a single text string that spans a complete row (multiple columns) within the table body. The \u201cindex column\u201d is a single text string in the first column (sometimes known as a stub) within the table body when either only the first column does not have a header, or the cell spans more than one row. The presence of a super row or index column indicates a table section division where the previous section (if present) ends, and a new section starts. The super row or index column text string provides the section name. A nested array data structure of table content is built to relate column headers to data rows, working from top to bottom and left to right, with section headings occurring in between and grouping data rows. The algorithm extracts the table metadata of title, footer and caption. Table content and metadata are output in the table JSON format. The contents of table cells can be either string or number data types (we consider \u201ctrue\u201d and \u201cfalse\u201d booleans as strings) and are represented in the output file using the respective JSON data type. Cells that contain only scientific notation are converted to exponential notation and stored as a JSON number data type. All HTML text formatting is removed, however this distorts the meaning of positive exponents in text strings, for example n = 103 is represented as n = 103. To preserve the meaning of exponents within text strings, superscript characters are identified using superscript HTML element markup, for example n = 10 <sup>3</sup>.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 22534,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Processing Table HTML ",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "Some publication tables contain content that could be represented in two or more separate tables. These multi-dimensional tables use the same gridlines, but new column headers are declared after initial column headers and data rows have appeared in the table. New column headers are identified by looking down columns and classifying each cell as one of three types: numerical, textual, and a mix of numbers and text. The type for a column is determined by the dominant cell type of all rows in a column excluding super rows. After the type of all columns are determined, the algorithm loops through all rows except super rows, and if more than half of cells in the row do not match with the columns' types, the row is identified as a new header row, and the rows that follow the new headers are then regarded as a sub-table. Auto-CORPus represents sub-tables as distinct tables in the table JSON, with identical metadata to the initial table. Tables are identified by the table number used in the publication, so since sub-tables will share their table number with the initial table, a new identifier is created for sub-tables with the initial table number, an underscore, then a sub-table number such as \u201c1_1.\u201d",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 23746,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Comparative Analysis of Outputs",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "The correspondence between PMC BioC and Auto-CORPus BioC outputs were compared to evaluate whether all information present in the PMC BioC output also appears in the Auto-CORPus BioC output. This was done by analyzing the number of characters in the PMC BioC JSON that appear in the same order in the Auto-CORPus BioC JSON using the longest common subsequence method. With this method, overlapping sequences of characters that vary in length are extracted from the PMC BioC string to find a matching sequence in the Auto-CORPus string. With this method it can occur that a subsequence from the PMC BioC matches to multiple parts of the Auto-CORPus BioC string (e.g., repeated words). This is mitigated by evaluating matches of overlapping/adjacent subsequences which should all be close to each other as they appear in the PMC BioC text.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 24614,
-                    "infons": {
-                        "section_title_1": "Materials and Methods",
-                        "section_title_2": "Comparative Analysis of Outputs",
-                        "iao_name_1": "materials section",
-                        "iao_id_1": "IAO:0000633",
-                        "iao_name_2": "methods section",
-                        "iao_id_2": "IAO:0000317"
-                    },
-                    "text": "This longest common subsequence method was applied to each individual paragraph of the PMC BioC input and compared with the Auto-CORPus BioC paragraphs. This method was chosen over other string metric algorithms, such as the Levenshtein distance or cosine-similarity, due to it being non-symmetric/unidirectional (the Auto-CORPus BioC output strings contain more information (e.g., figure/table links, references) than the PMC BioC output) and ability to directly extract different characters.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 25107,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Data for the Evaluation of Algorithms",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "We attempted to download PMC BioC JSON format for all 1,200 GWAS PMC publications in our OA dataset, but only 766 were available as BioC from the NCBI server. We refer to this as the \u201cPMC BioC dataset.\u201d For the 766 PMC articles where we could obtain a NCBI BioC file, we processed the equivalent PMC HTML files using Auto-CORPus. We used only the BioC output files and refer to this as the \u201cAuto-CORPus BioC dataset.\u201d To compare the Auto-CORPus BioC and table outputs for PMC and publisher-specific versions, we accessed 163 Nature Communication and 5 Nature Genetics articles that overlap with the OA dataset and were not present in the publisher dataset, so they were unseen data. These journals have linked tables, so full-text and all linked table HTML files were accessed (367 linked table files). Auto-CORPus configuration files were setup for the journals to process the publisher-specific files and the BioC and table JSON output files were collated into what we refer to as the \u201clinked table dataset.\u201d The equivalent PMC HTML files from the OA dataset were also processed by Auto-CORPus and the BioC and table JSON files form the \u201cinline table dataset.\u201d",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 26313,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "The proportion of characters from 3,195 full-text paragraphs in the PMC BioC dataset that also appear in the Auto-CORPus BioC dataset in the same order in the paragraph string were evaluated using the longest common subsequence method. The median and interquartile range of the (left-skewed) similarity are 100% and 100\u2013100%, respectively. Differences between the Auto-CORPus and PMC outputs are shown in Table 4 and relate to how display items, abbreviations and links are stored, and different character encodings. A structural difference between the two outputs is in how section titles are associated to passage text. In PMC BioC the section titles (and subtitles) are distinct from the passages they describe as both are treated as equivalent text. The section title occurs once in the file and the passage(s) it refers to follows it. In Auto-CORPus BioC the (first level) section titles (and subtitles) are linked directly with the passage text they refer to, and are included for each paragraph. Auto-CORPus uses IAO to classify text sections so, for example, the introduction title and text are grouped into a section annotated as introduction, rather than splitting these into two subsections (introduction title and introduction text as separate entities in the PMC BioC output) which would not fit with the IAO structure.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 27692,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "The Auto-CORPus BioC output includes the figure captions where they appear in the text and a separate table JSON file to store the table data, whereas the PMC BioC adds these data at the end of the JSON document and provides table content as a block of XML. Abbreviation sections are not included in the Auto-CORPus BioC output since Auto-CORPus provides a dedicated abbreviations JSON output. In the PMC BioC format the abbreviations and definitions are not related, whereas in the Auto-CORPus abbreviations JSON output the two elements are related. If an abbreviation does not contain a definition in the abbreviations section (perhaps due to an editorial error), PMC BioC will include the undefined thus meaningless abbreviation string, whereas Auto-CORPus will ignore it. Link anchor text to figures, tables, references and URLs are retained in the Auto-CORPus output but removed in the PMC BioC output. The most common differences between the two BioC versions is the encodings/strings used to reflect different whitespace characters and other special characters, with the remaining content being identical.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 28804,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "The proportion of characters from 9,468 full-text paragraphs in the publisher dataset that also appear in the Auto-CORPus PMC BioC dataset in the same order in the paragraph string were evaluated. The median and interquartile range of the (left-skewed) similarity is also 100 and 100\u2013100%, respectively, and differences between the PMC and publisher-versions are the same as those previously observed and reported in Table 4.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 29229,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "Last, we evaluated the section title mapping to IAO terms for publication from non-biomedical domains (physics, psychology). We observed that not all publications from these domains have standardized headers that can be mapped directly or with fuzzy matching and require the digraph to map headers. Most headers are mapped correctly either to one or multiple (potential) IAO terms (Supplementary Table 1). Only one publication contained a mismatch where two sections were mapped to introduction and methods sections, respectively, where each of these contained sub-headers that relate to introduction, methods and results. In two physics publications we encountered the case where the \u201cproportional to\u201d sign (\u221d) could not be mapped by the encoder.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 29976,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Table Processing ",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "We assessed the accuracy of the table JSON output generated from non-PMC linked tables compared with table JSON output generated from the equivalent PMC HTML with inline tables. The comparative analysis method described above was used for comparing BioC output from the linked table and inline table datasets, except here it was applied to both strings (bidirectional, taking the maximum value of both outcomes). This is equivalent to the Levenshtein similarity applied to transform the larger string into the smaller string, with the exception that the different characters for both comparisons are retained for identifying the differences. The correspondence between table JSON files in the linked table and inline table datasets was calculated as the number of characters correctly represented in the publishers table JSON output relative to the PMC versions [also using the (symmetric) longest common subsequence method]. Both the text and table similarity are represented as the median (inter-quartile range) to account for non-normal distributions of the data. Any differences identified during these analyses were at the paragraph or table row level, enabling manual investigation of these sections in a side-by-side comparison of the files.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 31268,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Performance of Auto-CORPus Table Processing ",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "The proportion of characters from 367 tables in the linked table dataset that also appear in the inline table dataset in the same order in the cell or text string were evaluated. The median and interquartile range of the (left-skewed) similarity is 100 and 99.79\u2013100.00%, respectively. We found that there were structural differences between some of the output files where additional data rows were present in the JSON files generated from the publisher's files. This occurred because cell value strings in tables from the publisher's files were split across two rows, however in the PMC version the string was formatted (wrapped) to be contained within a single row. The use of different table structures to contain the same data resulted in accurate but differing table JSON outputs. Most of the differences between table content and metadata values pertain to the character encoding used in the different table versions. For example, we have found different uses of hyphen/em dash/en dash/minus symbols between different versions, and Greek letters were represented differently in the different table versions. Other differences are related to how numbers are represented in scientific notation. If a cell contains a number only, then it is represented as a JSON number data type in the output. However, if the cell contains non-numeric characters, then there is no standardization of the cell text and the notation used (e.g., the \u00d7 symbol or E notation) will be reproduced in the JSON output. When there is variation in notation between sources, the JSON outputs will differ. Other editorial differences include whether thousands are represented with or without commas and how whitespace characters are used. Despite these variations there was no information loss between processed inline and linked tables.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 33080,
-                    "infons": {
-                        "section_title_1": "Results",
-                        "section_title_2": "Application: NER on GWAS Publications",
-                        "iao_name_1": "results section",
-                        "iao_id_1": "IAO:0000318"
-                    },
-                    "text": "Our intention is that Auto-CORPus supports information extraction from the biomedical literature. To demonstrate the use of Auto-CORPus outputs within a real-world application and aligned to the authors' expertise to support the evaluation of the results, we applied named-entity recognition (NER) to the Auto-CORPus BioC full-text output to extract GWAS metadata. Study metadata are included in curated GWAS databases, such as GWAS Central, and the ability to extract these entities automatically could provide a valuable curation aid. Full details of the method and the rationale behind the application is provided in the Supplementary Methods. In summary, we filtered out sentences in the methods sections from the BioC full-text output that contain information on the genotyping platforms, assays, total number of genetic variants, quality control and imputation that were used. We trained five separate algorithms for NER (one for each metadata type) using 700 GWAS publications and evaluated these on 500 GWAS publications of the test set. The F1-scores for the five tasks are between 0.82 and 1.00 (Supplementary Table 2) with examples given in Supplementary Figure 4.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 34292,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Strengths and Limitations",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "We have shown that Auto-CORPus brings together and bolsters several disjointed standards (BioC and IAO) and algorithmic components (for processing tables and abbreviations) of scientific literature analytics into a convenient and reliable tool for standardizing full-text and tables. The BioC format is a useful but not ubiquitous standard for representing text and annotations. Auto-CORPus enables the transformation of the widely available HTML format into BioC JSON following the setup of a configuration file associated with the structure of the HTML documents. The use of the configuration file drives the flexibility of the package, but also restricts use to users who are confident exploring HTML document structures. We make available the configuration files used in the evaluations described in this paper. To process additional sources, an upfront time investment is required from the user to explore the HTML structure and set the configuration file. We will be increasing the number of configuration files available for larger publishers, and we help non-technical users by providing documentation to explain how to setup configuration files. We welcome configuration files submitted by users and the documentation describes the process for users to submit files. Configuration files contain a section for tracking contributions made to the file, so the names of authors and editors can be logged. Once a configuration file has been submitted and tested, the file will be included within the Auto-CORPus package and the user credited (should they wish) with authorship of the file.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 35920,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Strengths and Limitations",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "The inclusion of IAO terms within the Auto-CORPus BioC output standardizes the description of publication sections across all processed sources. The digraph that is used to assign unmapped paragraph headers to standard IAO terms was constructed using both GWAS and MWAS literature to avoid training it to be used for a single domain only. We have tested the algorithms on PMC articles from three different physics and three psychology journals to confirm the BioC JSON output and IAO term recognition extend beyond only biomedical literature. Virtually all header terms from these articles were mapped to relevant IAO terms even when not all headers could be mapped, however some sections were mapped to multiple IAO terms based on paths in the digraph. Since ontologies are stable but not static, any resource or service that relies on one ontology structure could become outdated or redundant as the ontology is updated. We will rerun the fuzzy matching of headers to IAO terms and regenerate the digraph as new terms are introduced to the document part branch of IAO. We have experience of this when our first group of term suggestions based on the digraph were included into the IAO.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 37107,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Strengths and Limitations",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "The BioC output of abbreviations contains the abbreviation, definition and the algorithm(s) by which each pair was identified. One limitation of the current full-text abbreviation algorithm is that it searches for abbreviations in brackets and therefore will not find abbreviations for which the definition is in brackets, or abbreviations that are defined without use of brackets. The current structure of the abbreviation JSON allows additional methods to be included alongside the two methods currently used. Adding further algorithms to find different types of abbreviation in the full-text is considered as part of future work.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 37739,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Strengths and Limitations",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "Auto-CORPus implements a method for extracting table structures and data that was developed to extract table information from XML formatted tables (8). The use of the configuration file for identifying table containers enables the table processing to be focused on relevant data tables and exclude other tables associated with web page formatting. Auto-CORPus is distinct from other work in this field that uses machine learning methods to classify the types of information within tables (16). Auto-CORPus table processing is agnostic to the extracted variables, with the only distinction made between numbers and strings for the pragmatic reason of correctly formatting the JSON data type. The table JSON files could be used in downstream analysis (and annotation) of cell information types, but the intention of Auto-CORPus is to provide the capability to generate a faithful standardized output from any HTML source file. We have shown high accuracy (>99%) for the tables we have processed with a configuration file and the machine learning method was shown to recover data from ~86% of tables (16). Accurate extraction is possible across more data sources with the Auto-CORPus rule-based approach, but a greater investment in setup time is required.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 38992,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Strengths and Limitations",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "Auto-CORPus focuses on HTML versions of articles as these are readily and widely available within the biomedical domain. Currently the processing of PDF documents is not supported, but the work by the Semantic Scholar group to convert PDF documents to HTML is encouraging as they observed that 87% of PDF documents processed showed little to no readability issues (4). The ability to leverage reliable document transformation will have implications for processing supplementary information files and broader scientific literature sources which are sometimes only available in PDF format, and therefore will require conversion to the accessible and reusable HTML format.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 39661,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Future Research and Conclusions",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "We found that the tables for some publications are made available as images (see Table 1), so could not be processed by Auto-CORPus. To overcome this gap in publication table standardization, we are refining a plugin for Auto-CORPus that provides an algorithm for processing images of tables. The algorithm leverages Google's Tesseract optical character recognition engine to extract text from preprocessed table images. An overview of the table image processing pipeline is available in Supplementary Figure 3. During our preliminary evaluation of the plugin, it achieved an accuracy of ~88% when processing a collection of 200 JPG and PNG table images taken from 23 different journals. Although encouraging, there are caveats in that the image formats must be of high resolution, the algorithm performs better on tables with gridlines than tables without gridlines, special characters are rarely interpreted correctly, and cell text formatting is lost. We are fine tuning the Tesseract model by training new datasets on biomedical data. An alpha release of the table image processing plugin is available with the Auto-CORPus package.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 40827,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Future Research and Conclusions",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "The authors are involved in omics health data NLP projects that use Auto-CORPus within text mining pipelines to standardize and optimize biomedical literature ahead of entity and relation annotations and have given examples in the Supplementary Material of how the Auto-CORPus output was used to train these algorithms. The BioC format supports the stand-off annotation of linguistic features such as tokens, part-of-speech tags and noun phrases, as well as the annotation of relations between these elements (5). We are developing machine learning methods to automatically extract genome-wide association study (GWAS) data from peer-reviewed literature. High quality annotated datasets are required to develop and train NLP algorithms and validate the outputs. We are developing a GWAS corpus that can be used for this purpose using a semi-automated annotation method. The GWAS Central database is a comprehensive collection of summary-level GWAS findings imported from published research papers or submitted by study authors (13). For GWAS Central studies, we used Auto-CORPus to standardize the full-text publication text and tables. In an automatic annotation step, for each publication, all GWAS Central association data was retrieved. Association data consists of three related entities: a phenotype/disease description, genetic marker, and an association P-value. A named entity recognition algorithm identifies the database entities in the Auto-CORPus BioC and table JSON files. The database entities and relations are mapped back onto the text, by expressing the annotations in BioC format and appending these to the relevant BioC element in the JSON files. The automatic annotations are then manually evaluated using the TeamTat text annotation tool which provides a user-friendly interface for annotating entities and relations (17). We use TeamTat to manually inspect the automatic annotations and modify or remove incorrect annotations, in addition to including new annotations that were not automatically generated. TeamTat accepts BioC input files and outputs in BioC format, thus the Auto-CORPus files that have been automatically annotated are suitable for importing into TeamTat. Work to create the GWAS corpus is ongoing, but the convenient semi-automatic process for creating high-quality annotations from biomedical literature HTML files described here could be adapted for creating other gold-standard corpora.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 43259,
-                    "infons": {
-                        "section_title_1": "Discussion",
-                        "section_title_2": "Future Research and Conclusions",
-                        "iao_name_1": "discussion section",
-                        "iao_id_1": "IAO:0000319"
-                    },
-                    "text": "In related work, we are developing a corpus for MWAS for metabolite named-entity recognition to enable the development of new NLP tools to speed up literature review. As part of this, the active development focuses on extending Auto-CORPus to analyse preprint literature and Supplementary Materials, improving the abbreviation detection, and development of more configuration files. Our preliminary work on preprint literature has shown we can map paragraphs in Rxiv versions to paragraphs in the peer-reviewed manuscript with the high accuracy (average similarity of paragraphs >95%). Another planned extension is to classify paragraphs based on the text in the case where headers are mapped to multiple IAO terms. The flexibility of the Auto-CORPus configuration file enables researchers to use Auto-CORPus to process publications and data from a broad variety of sources to create reusable corpora for many use cases in biomedical literature and other scientific fields.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 44232,
-                    "infons": {
-                        "section_title_1": "Author Contributions",
-                        "iao_name_1": "author contributions section",
-                        "iao_id_1": "IAO:0000323"
-                    },
-                    "text": "TB and JP designed and supervised the research and wrote the manuscript. TB contributed the GWAS use case and JP contributed the MWAS/metabolomics use cases. TS developed the BioC outputs and led the coding integration aspects. YH developed the section header standardization algorithm and implemented the abbreviation recognition algorithm. ZL developed the table image recognition and processing algorithm. SS developed the table extraction algorithm and main configuration file. CP developed configuration files for preprint texts. NM developed the NER algorithms for GWAS entity recognition. NM, FM, CY, ZL, and CP tested the package and performed comparative analysis of outputs. TR refined standardization of full-texts and contributed algorithms for character set conversions. All authors read, edited, and approved the manuscript.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 45090,
-                    "infons": {
-                        "section_title_1": "Funding",
-                        "iao_name_1": "funding source declaration section",
-                        "iao_id_1": "IAO:0000623"
-                    },
-                    "text": "This work has been supported by Health Data Research (HDR) UK and the Medical Research Council via an UKRI Innovation Fellowship to TB (MR/S003703/1) and a Rutherford Fund Fellowship to JP (MR/S004033/1).",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 45301,
-                    "infons": {
-                        "section_title_1": "Conflict of Interest",
-                        "iao_name_1": "conflict of interest section",
-                        "iao_id_1": "IAO:0000616"
-                    },
-                    "text": "The authors declare that the research was conducted in the absence of any commercial or financial relationships that could be construed as a potential conflict of interest.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 45493,
-                    "infons": {
-                        "section_title_1": "Publisher's Note",
-                        "iao_name_1": "notes section",
-                        "iao_id_1": "IAO:0000634"
-                    },
-                    "text": "All claims expressed in this article are solely those of the authors and do not necessarily represent those of their affiliated organizations, or those of the publisher, the editors and the reviewers. Any product that may be evaluated in this article, or claim that may be made by its manufacturer, is not guaranteed or endorsed by the publisher.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 45855,
-                    "infons": {
-                        "section_title_1": "Acknowledgments",
-                        "iao_name_1": "acknowledgements section",
-                        "iao_id_1": "IAO:0000324"
-                    },
-                    "text": "We thank Mohamed Ibrahim (University of Leicester) for identifying different configurations of tables for different HTML formats.",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 45999,
-                    "infons": {
-                        "section_title_1": "Supplementary Material",
-                        "iao_name_1": "supplementary material section",
-                        "iao_id_1": "IAO:0000326"
-                    },
-                    "text": "The Supplementary Material for this article can be found online at: https://www.frontiersin.org/articles/10.3389/fdgth.2022.788124/full#supplementary-material",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 46179,
-                    "infons": {
-                        "title": "Natural language processing of clinical notes on chronic diseases: systematic review",
-                        "journal": "JMIR Med Inform.",
-                        "volume": "7",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "1. Sheikhalishahi S, Miotto R, Dudley JT, Lavelli A, Rinaldi F, Osmani V. Natural language processing of clinical notes on chronic diseases: systematic review. JMIR Med Inform. (2019) 7:e12239. 10.2196/12239 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 46452,
-                    "infons": {
-                        "title": "Natural language processing to extract symptoms of severe mental illness from clinical text: the Clinical Record Interactive Search Comprehensive Data Extraction (CRIS-CODE) project",
-                        "journal": "BMJ Open",
-                        "volume": "7",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "2. Jackson RG, Patel R, Jayatilleke N, Kolliakou A, Ball M, Gorrell G, et al.. Natural language processing to extract symptoms of severe mental illness from clinical text: the Clinical Record Interactive Search Comprehensive Data Extraction (CRIS-CODE) project. BMJ Open. (2017) 7:e012012. 10.1136/bmjopen-2016-012012 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 46825,
-                    "infons": {
-                        "title": "Status of text-mining techniques applied to biomedical text",
-                        "journal": "Drug Discov Today.",
-                        "volume": "11",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "3. Erhardt RA, Schneider R, Blaschke C. Status of text-mining techniques applied to biomedical text. Drug Discov Today. (2006) 11:315\u201325. 10.1016/j.drudis.2006.02.011 [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 47028,
-                    "infons": {
-                        "title": "Improving the accessibility of scientific documents: current state, user needs, and a system solution to enhance scientific PDF accessibility for blind and low vision users",
-                        "journal": "arXiv e-prints: arXiv:2105.00076",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "4. Wang LL, Cachola I, Bragg J, Yu-Yen Cheng E, Haupt C, Latzke M, et al.. Improving the accessibility of scientific documents: current state, user needs, and a system solution to enhance scientific PDF accessibility for blind and low vision users. arXiv e-prints: arXiv:2105.00076 (2021). Available online at: https://arxiv.org/pdf/2105.00076.pdf",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 47375,
-                    "infons": {
-                        "title": "BioC: a minimalist approach to interoperability for biomedical text processing",
-                        "journal": "Database.",
-                        "volume": "2013",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "5. Comeau DC, Islamaj Dogan R, Ciccarese P, Cohen KB, Krallinger M, Leitner F, et al.. BioC: a minimalist approach to interoperability for biomedical text processing. Database. (2013) 2013:bat064. 10.1093/database/bat064 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 47651,
-                    "infons": {
-                        "title": "PMC text mining subset in BioC: about three million full-text articles and growing",
-                        "journal": "Bioinformatics.",
-                        "volume": "35",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "6. Comeau DC, Wei CH, Islamaj Dogan R, Lu Z. PMC text mining subset in BioC: about three million full-text articles and growing. Bioinformatics. (2019) 35:3533\u20135. 10.1093/bioinformatics/btz070 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 47899,
-                    "infons": {
-                        "title": "An information artifact ontology perspective on data collections and associated representational artifacts",
-                        "journal": "Stud Health Technol Inform.",
-                        "volume": "180",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "7. Ceusters W. An information artifact ontology perspective on data collections and associated representational artifacts. Stud Health Technol Inform. (2012) 180:68\u201372. 10.3233/978-1-61499-101-4-68 [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 48133,
-                    "infons": {
-                        "title": "Disentangling the structure of tables in scientific literature",
-                        "journal": "Natural Language Processing and Information Systems",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "8. Milosevic N, Gregson C, Hernandez R, Nenadic G. Disentangling the structure of tables in scientific literature. In: M\u00e9tais E, Meziane F, Saraee M, Sugumaran V, Vadera S, editors. Natural Language Processing and Information Systems. Cham: Springer International Publishing; (2016). p. 162\u201374. 10.1007/978-3-319-41754-7_14 [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 48484,
-                    "infons": {
-                        "title": "Constructing biological knowledge bases by extracting information from text sources",
-                        "journal": "International Conference on Intelligent Systems for Molecular Biology.",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "9. Craven M, Kumlien J. Constructing biological knowledge bases by extracting information from text sources. In: International Conference on Intelligent Systems for Molecular Biology.Heidelberg: (1999) p. 77\u201386. [PubMed] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 48721,
-                    "infons": {
-                        "title": "Automatic extraction of biological information from scientific text: protein-protein interactions",
-                        "journal": "International Conference on Intelligent Systems for Molecular Biology",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "10. Blaschke C, Andrade MA, Ouzounis C, Valencia A. Automatic extraction of biological information from scientific text: protein-protein interactions. In: International Conference on Intelligent Systems for Molecular Biology. Heidelberg: (1999) p. 60\u20137. [PubMed] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 49000,
-                    "infons": {
-                        "title": "Automatic annotation for biological sequences by extraction of keywords from MEDLINE abstracts. Development of a prototype system",
-                        "journal": "Proc Int Conf Intell Syst Mol Biol.",
-                        "volume": "5",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "11. Andrade MA, Valencia A. Automatic annotation for biological sequences by extraction of keywords from MEDLINE abstracts. Development of a prototype system. Proc Int Conf Intell Syst Mol Biol. (1997) 5:25\u201332. [PubMed] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 49236,
-                    "infons": {
-                        "title": "A simple algorithm for identifying abbreviation definitions in biomedical text",
-                        "journal": "Pac Symp Biocomput.",
-                        "volume": "8",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "12. Schwartz AS, Hearst MA. A simple algorithm for identifying abbreviation definitions in biomedical text. Pac Symp Biocomput. (2003) 8:451\u201362. Available online at: https://psb.stanford.edu/psb-online/proceedings/psb03/schwartz.pdf [PubMed] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 49494,
-                    "infons": {
-                        "title": "GWAS Central: a comprehensive resource for the discovery and comparison of genotype and phenotype data from genome-wide association studies",
-                        "journal": "Nucleic Acids Res",
-                        "volume": "48",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "13. Beck T, Shorter T, Brookes AJ. GWAS Central: a comprehensive resource for the discovery and comparison of genotype and phenotype data from genome-wide association studies. Nucleic Acids Res. (2020) 48:D933\u201340. 10.1093/nar/gkz895 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 49782,
-                    "infons": {
-                        "title": "Creating mappings for ontologies in biomedicine: simple methods work",
-                        "journal": "AMIA Annu Symp Proc.",
-                        "volume": "2009",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "14. Ghazvinian A, Noy NF, Musen MA. Creating mappings for ontologies in biomedicine: simple methods work. AMIA Annu Symp Proc. (2009) 2009:198\u2013202. [PMC free article] [PubMed] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 49974,
-                    "infons": {
-                        "title": "Trans-ethnic meta-analysis of white blood cell phenotypes",
-                        "journal": "Hum Mol Genet.",
-                        "volume": "23",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "15. Keller MF, Reiner AP, Okada Y, van Rooij FJ, Johnson AD, Chen MH, et al.. Trans-ethnic meta-analysis of white blood cell phenotypes. Hum Mol Genet. (2014) 23:6944\u201360. 10.1093/hmg/ddu401 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 50219,
-                    "infons": {
-                        "title": "A framework for information extraction from tables in biomedical literature",
-                        "journal": "Int J Docum Anal Recogn.",
-                        "volume": "22",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "16. Milosevic N, Gregson C, Hernandez R, Nenadic G. A framework for information extraction from tables in biomedical literature. Int J Docum Anal Recogn. (2019) 22:55\u201378. 10.1007/s10032-019-00317-0 [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                },
-                {
-                    "offset": 50444,
-                    "infons": {
-                        "title": "TeamTat: a collaborative text annotation tool",
-                        "journal": "Nucleic Acids Res",
-                        "volume": "48",
-                        "section_title_1": "References",
-                        "iao_name_1": "references section",
-                        "iao_id_1": "IAO:0000320"
-                    },
-                    "text": "17. Islamaj R, Kwon D, Kim S, Lu Z. TeamTat: a collaborative text annotation tool. Nucleic Acids Res. (2020) 48:W5\u201311. 10.1093/nar/gkaa333 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
-                    "sentences": [],
-                    "annotations": [],
-                    "relations": []
-                }
-            ],
-            "annotations": [],
-            "relations": []
+          "offset": 0,
+          "infons": {
+            "iao_name_1": "document title",
+            "iao_id_1": "IAO:0000305"
+          },
+          "text": "Auto-CORPus: A Natural Language Processing Tool for Standardizing and Reusing Biomedical Literature",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 99,
+          "infons": {
+            "section_title_1": "keywords",
+            "iao_name_1": "keywords section",
+            "iao_id_1": "IAO:0000630"
+          },
+          "text": "natural language processing, text mining, biomedical literature, semantics, health data",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 194,
+          "infons": {
+            "section_title_1": "document part",
+            "iao_name_1": "document part",
+            "iao_id_1": "IAO:0000314"
+          },
+          "text": "Publicly available datasets were analyzed in this study. The Auto-CORPus package is freely available from GitHub (https://github.com/omicsNLP/Auto-CORPus) and can be deployed on local machines as well as using high-performance computing to process publications in batch. A step-by-step guide to detail how to use Auto-CORPus is supplied with the package. Data from both Open Access (via PubMed Central) and publisher repositories are used, the latter were downloaded within university library licenses and cannot be shared.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 730,
+          "infons": {
+            "section_title_1": "Abstract",
+            "iao_name_1": "textual abstract section",
+            "iao_id_1": "IAO:0000315"
+          },
+          "text": "To analyse large corpora using machine learning and other Natural Language Processing (NLP) algorithms, the corpora need to be standardized. The BioC format is a community-driven simple data structure for sharing text and annotations, however there is limited access to biomedical literature in BioC format and a lack of bioinformatics tools to convert online publication HTML formats to BioC. We present Auto-CORPus (Automated pipeline for Consistent Outputs from Research Publications), a novel NLP tool for the standardization and conversion of publication HTML and table image files to three convenient machine-interpretable outputs to support biomedical text analytics. Firstly, Auto-CORPus can be configured to convert HTML from various publication sources to BioC. To standardize the description of heterogenous publication sections, the Information Artifact Ontology is used to annotate each section within the BioC output. Secondly, Auto-CORPus transforms publication tables to a JSON format to store, exchange and annotate table data between text analytics systems. The BioC specification does not include a data structure for representing publication table data, so we present a JSON format for sharing table content and metadata. Inline tables within full-text HTML files and linked tables within separate HTML files are processed and converted to machine-interpretable table JSON format. Finally, Auto-CORPus extracts abbreviations declared within publication text and provides an abbreviations JSON output that relates an abbreviation with the full definition. This abbreviation collection supports text mining tasks such as named entity recognition by including abbreviations unique to individual publications that are not contained within standard bio-ontologies and dictionaries. The Auto-CORPus package is freely available with detailed instructions from GitHub at: https://github.com/omicsNLP/Auto-CORPus.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 2662,
+          "infons": {
+            "section_title_1": "Introduction",
+            "iao_name_1": "introduction section",
+            "iao_id_1": "IAO:0000316"
+          },
+          "text": "Natural language processing (NLP) is a branch of artificial intelligence that uses computers to process, understand, and use human language. NLP is applied in many different fields including language modeling, speech recognition, text mining, and translation systems. In the biomedical realm NLP has been applied to extract, for example, medication data from electronic health records and patient clinical history from free-text (unstructured) clinical notes, to significantly speed up processes that would otherwise be extracted manually by experts (1, 2). Biomedical research publications, although semi-structured, pose similar challenges with regards to extracting and integrating relevant information (3). The full-text of biomedical literature is predominately made available online in the accessible and reusable HTML format, however, some publications are only available as PDF documents which are more difficult to reuse. Efforts to resolve the problem of publication text accessibility across science in general includes work by the Semantic Scholar search engine to convert PDF documents to HTML formats (4). Whichever process is used to obtain a suitable HTML file, before the text can be processed using NLP, heterogeneously structured HTML requires standardization and optimization. BioC is a simple JSON (and XML) format for sharing and reusing text data that has been developed by the text mining community to improve system interoperability (5). The BioC data model consists of collections of documents divided into data elements such as publication sections and associated entity and relation annotations. PubMed Central (PMC) makes full-text articles from its Open Access and Author Manuscript collections available in BioC format (6). To our knowledge there are no services available to convert PMC publications that are not part of these collections to BioC. Additionally, there is a gap in available software to convert publishers' publication HTML to BioC, creating a bottleneck in many biomedical literature text mining workflows caused by having to process documents in heterogenous formats. To bridge this gap, we have developed an Automated pipeline for Consistent Outputs from Research Publications (Auto-CORPus) that can be configured to process any HTML publication structure and transform the corresponding publications to BioC format.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 5040,
+          "infons": {
+            "section_title_1": "Introduction",
+            "iao_name_1": "introduction section",
+            "iao_id_1": "IAO:0000316"
+          },
+          "text": "During information extraction, the publication section context of an entity will assist with entity prioritization. For example, an entity identified in the Results Section may be regarded as a higher priority novel finding than one identified in the Introduction Section. However, the naming and the sequential order of sections within research articles differ between publications. A Methods section, for example, may be found at different locations relative to other sections and identified using a range of synonyms such as experimental section, experimental procedures, and methodology. The Information Artifact Ontology (IAO) was created to serve as a domain-neutral resource for the representation of types of information content entities such as documents, databases, and digital images (7). Auto-CORPus applies IAO annotations to BioC file outputs to standardize the description of sections across all processed publications.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 5974,
+          "infons": {
+            "section_title_1": "Introduction",
+            "iao_name_1": "introduction section",
+            "iao_id_1": "IAO:0000316"
+          },
+          "text": "Vast amounts of biomedical data are contained in publication tables which can be large and multi-dimensional where information beyond a standard two-dimensional matrix is conveyed to a human reader. For example, a table may have subsections or entirely new column headers to merge multiple tables into a single structure. Milosevic and colleagues developed a methodology to analyse complex tables that are represented in XML format and perform a semantic analysis to classify the data types used within a table (8). The outputs from the table analysis are stored in esoteric XML or database models. The communal BioC format on the other hand has limited support for tables, for example the PMC BioC JSON output includes table data in PMC XML format, introducing file parsing complexity. In addition to variations in how tables are structured, there is variability amongst table filetypes. Whereas, publication full-text is contained within a single HTML file, tables may be contained within that full-text file (inline tables), or individual tables may be contained in separate HTML files (linked tables). We have defined a dedicated table JSON format for representing table data from both formats of table. The contents of individual cells are unambiguously identified and thus can be used in entity and relation annotations. In developing the Auto-CORPus table JSON format, we adopted a similar goal to the BioC community, namely, a simple format to maximize interoperability and reuse of table documents and annotations. The table JSON reuses the BioC data model for entity and relation annotations, ensuring that table and full-text annotations can share the same BioC syntax. Auto-CORPus transforms both inline and linked HTML tables to the machine interpretable table JSON format.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 7760,
+          "infons": {
+            "section_title_1": "Introduction",
+            "iao_name_1": "introduction section",
+            "iao_id_1": "IAO:0000316"
+          },
+          "text": "Abbreviations and acronyms are widely used in publication text to reduce space and avoid prolix. Abbreviations and their definitions are useful in text mining to identify lexical variations of words describing identical entities. However, the frequent use of novel abbreviations in texts presents a challenge for the curators of biomedical lexical ontologies to ensure they are continually updated. Several algorithms have been developed to extract abbreviations and their definitions from biomedical text (9–11). Abbreviations within publications can be defined when they are declared within the full-text, and in some publications, are included in a dedicated abbreviations section. Auto-CORPus adapts an abbreviation detecting methodology (12) and couples it with IAO section detection to comprehensively extract abbreviations declared in the full-text and in the abbreviations section. For each publication, Auto-CORPus generates an abbreviations dictionary JSON file.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 8732,
+          "infons": {
+            "section_title_1": "Introduction",
+            "iao_name_1": "introduction section",
+            "iao_id_1": "IAO:0000316"
+          },
+          "text": "The aim of this article is to describe the open Auto-CORPus python package and the text mining use cases that make it a simple user-friendly application to create machine interpretable biomedical literature files, from a single publication to a large corpus. The authors share the common interest of progressing text mining capabilities across the biomedical literature domain and contribute omics and health data use cases related to their expertise in Genome-Wide Association Study (GWAS) and Metabolome-Wide Association Study (MWAS) data integration and analytics (see Author Contributions Section). The following sections describe the technical details about the algorithms developed and the benchmarking undertaken to assess the quality of the three Auto-CORPus outputs generated for each publication: BioC full-text, Auto-CORPus tables, and Auto-CORPus abbreviations JSON files.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 9616,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Data for Algorithm Development",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "We used a set of 3,279 full-text HTML and 1,041 linked table files to develop and test the algorithms described in this section. Files for 1,200 Open Access (OA) GWAS publications whose data exists in the GWAS Central database (13) were downloaded from PMC in March 2020. A further 1,241 OA PMC publications of MWAS and metabolomics studies on cancer, gastrointestinal diseases, metabolic syndrome, sepsis and neurodegenerative, psychiatric, and brain illnesses were also downloaded to ensure the methods are not biased toward one domain, more information is available in the Supplementary Material. This formed a collection of 2,441 publications that will be referred to as the “OA dataset.” We also downloaded publisher-specific full-text files, and linked table data were available, for publications whose data exists in the GWAS Central database. This collection of 838 full-text and 1,041 table HTML files will be referred to as the “publisher dataset.” Table 1 lists the publishers and journals included in the publisher dataset and the number of publications that overlap with the OA dataset. This also includes publications from non-biomedical fields to evaluate the application in other domains.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 10871,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Algorithms for Processing Publication Full-Text HTML",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "An Auto-CORPus configuration file is set by the user to define the heading and paragraph HTML elements used in the publication files to be processed. Regular expressions can be used within the configuration file allowing a group of publications with a similar but not an identical structure to be defined by a single configuration file, for example when processing publications from journals by the same publisher. The heading elements are used to delineate the content of the publication sections and the BioC data structure is populated with publication text. All HTML tags including text formatting (e.g., emphasized words, superscript, and subscript) are removed from the publication text. Each section is automatically annotated using IAO (see Section Algorithms for Classifying Publication Sections With IAO Terms) and the BioC data structure is output in JSON format. The BioC specification requires “key files” to accompany BioC data files to specify how the data files should be interpreted (5). We provide key files to define the data elements in the Auto-CORPus JSON output files for full-text, tables, and abbreviations (https://github.com/omicsNLP/Auto-CORPus/tree/main/keyFiles). Figure 1 gives an example of the BioC JSON output and the abbreviations and tables outputs are described below.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 12228,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Algorithms for Processing Publication Full-Text HTML",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "Abbreviations in the full-text are found using an adaptation of a previously published methodology and implementation (12). The method finds all brackets within a publication and if there are two or more non-digit characters within brackets it considers if the string in the brackets could be an abbreviation. It searches for the characters present in the brackets in the text on either side of the brackets one by one. The first character of one of these words must contain the first character within the bracket, and the other characters within that bracket must be contained by other words that follow the first word whose first character is the same as the first character in that bracket. An example of the Auto-CORPus abbreviations JSON is given in Figure 2 which shows that the output from this algorithm is stored along with the abbreviations defined in the publication abbreviations section (if present).",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 13141,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Algorithms for Classifying Publication Sections With IAO Terms",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "A total of 21,849 section headers were extracted from the OA dataset and directed path graphs (DPGs) were created for each publication (Figure 3). DPGs are a linear chain without any cycles. For example, at this point in this article the main headers are abstract (one paragraph) followed by introduction (five paragraphs) and materials and methods (four paragraphs, three sub-headers)—this would make up a DPG with three nodes (abstract, introduction, materials and methods) and two directed edges. For our Introduction Section, while the individual five paragraphs within a section would all be mapped to the main header (introduction), only one node would appear in the DPG (relating to the header itself) without any self-edges. The individual DPGs were then combined into a directed graph (digraph, Supplementary Figure 2) and the extracted section headers were mapped to IAO (v2020-06-10) document part terms using the Lexical OWL Ontology Matcher (LOOM) method (14). Fuzzy matching using the fuzzywuzzy python package (v0.17.0) was then used to map headers to the preferred section header terms and synonyms, with a similarity threshold of 0.8 (e.g., the typographical error “experemintal section” in PMC4286171 is correctly mapped to methods section). This threshold was evaluated by two independent researchers who confirmed all matches for the OA dataset were accurate. Digraphs consist of nodes (entities, headers) and edges (links between nodes) and the weight of the nodes and edges is proportional to the number of publications in which these are found. Here the digraph consists of 372 unique nodes and 806 directed edges (Supplementary Figure 1).",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 14865,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Algorithms for Classifying Publication Sections With IAO Terms",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "However, after direct IAO mapping and fuzzy matching, unmapped headers still existed. To map these headings, we developed a new method using both the digraph and the individual DPGs. The headers are not repeated within a document/DPG, they are sequential/a chain and have a set order that can be exploited. Unmapped headers are assigned a section based on the digraph and the headers in the publication (DPG) that could be mapped (anchor headers), an example is given in Supplementary Figure 2 where a header cannot be mapped to IAO terms. Any unmapped header that is mapped to an existing IAO term in this manner does not result in a self-edge in the network as subsequent repeated headers are collapsed into a single node. Auto-CORPus uses the LOOM, fuzzy matching and digraph prediction algorithms to annotate publication sections with IAO terms in the BioC full-text file. Paragraphs can be mapped to multiple IAO terms in case of publications without main-text headers (based on digraph prediction) or with ambiguous headers (based on fuzzy matching and/or digraph prediction).",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 15947,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "New IAO Terms and Synonyms ",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "We used the IAO classification algorithms to identify potential new IAO terms and synonyms. Three hundred and forty-eight headings from the OA dataset were mapped to IAO terms during the fuzzy matching or mapped based on the digraph using the publication structure and anchor headers. These headings were considered for inclusion in IAO as term synonyms. We manually evaluated each heading and Table 2 lists the 94 synonyms we identified for existing IAO terms.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 16435,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "New IAO Terms and Synonyms ",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "Diagraph nodes that were not mapped to IAO terms but formed heavily weighted “ego-networks,” indicating the same heading was found in many publications, were manually evaluated for inclusion in IAO as new terms. For example, based on the digraph, we assigned data and data description to be synonyms of the materials section. The same process was applied to ego-networks from other nodes linked to existing IAO terms to add additional synonyms to simplify the digraph. Figure 4 shows the ego-network for abstract, and four main categories and one potential new synonym (precis, in red) were identified. From the further analysis of all ego-networks, four new potential terms were identified: disclosure, graphical abstract, highlights, and participants—the latter is related to, but deemed distinct from, the existing patients section (IAO:0000635). Table 3 details the proposed definition and synonyms for these terms. The terms and synonyms described here will be submitted to the IAO, with our initial submission of one term and 59 synonyms accepted and included in IAO previously (v2020-12-09) (https://github.com/information-artifact-ontology/IAO/issues/234). Figure 5 shows the resulting digraph with only existing and newly proposed section terms. A major unmapped node is associated data, which is a header specific for PMC articles that appears at the beginning of each article before the abstract. In addition, IAO has separate definitions for materials (IAO:0000633), methods (IAO:0000317), and statistical methods (IAO:0000644) sections, hence they are separate nodes in the graph. The introduction is often followed by these headers to reflect the methods section (and synonyms), however there is also a major directed edge from introduction directly to results to account for materials and methods placed after the discussion and/or conclusion sections in some publications.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 18323,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Auto-CORPus Table JSON Design ",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "The BioC format does not specify how table content should be structured, leaving this open to the interpretation of implementers. For example, the PMC BioC JSON output describes table content using PMC XML (see the “pmc.key” file at https://ftp.ncbi.nlm.nih.gov/pub/wilbur/BioC-PMC/pmc.key). Including markup language within JSON objects presents data parsing challenges and interoperability barriers with non-PMC table data representations. We developed a simple table JSON format that is agnostic to the publication table source, can store multi-dimensional table content from complex table structures, and applies BioC design principles (5) to enable the annotation of entities and relations between entities. The table JSON stores table metadata of title, caption and footer. The table content is stored as “column headers” and “data rows.” The format supports the use of IAO to define the table metadata and content sections, however additional IAO terms are required to define table metadata document parts. Table 3 includes the proposed definition and synonyms for these terms. To compensate for currently absent IAO terms, we have defined three section type labels: table title, table caption and table footer. To support the text mining of tables, each column header and data row cell has an identifier that can be used to identify entities in annotations. Tables can be arranged into subsections, thus the table JSON represents this and includes subsection headings. Figure 6 gives an example of table metadata and content stored in the Auto-CORPus table JSON format. In addition to the Auto-CORPus key files, we make a table JSON schema available for the validation of table JSON files and to facilitate the use of the format in text analytics software and pipelines.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 20131,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Processing Table HTML ",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "Tables can used within HTML documents for formatting web page layouts and are distinct from the data tables processed by Auto-CORPus. The configuration file set by the user identifies the HTML elements used to define data table containers, which include title, caption, footer, and table content. The files processed can either be a full-text HTML file for inline tables and/or separate HTML files for individual linked tables. The Auto-CORPus algorithm for processing tables is based on the functional and structural table analysis method described by Milosevic et al. (8). The cells that contain navigational information such as column headers and section headings are identified. If a column has header strings contained in cells spanning multiple rows, the strings are concatenated with a pipe character separator to form a single column header string. The “super row” is a single text string that spans a complete row (multiple columns) within the table body. The “index column” is a single text string in the first column (sometimes known as a stub) within the table body when either only the first column does not have a header, or the cell spans more than one row. The presence of a super row or index column indicates a table section division where the previous section (if present) ends, and a new section starts. The super row or index column text string provides the section name. A nested array data structure of table content is built to relate column headers to data rows, working from top to bottom and left to right, with section headings occurring in between and grouping data rows. The algorithm extracts the table metadata of title, footer and caption. Table content and metadata are output in the table JSON format. The contents of table cells can be either string or number data types (we consider “true” and “false” booleans as strings) and are represented in the output file using the respective JSON data type. Cells that contain only scientific notation are converted to exponential notation and stored as a JSON number data type. All HTML text formatting is removed, however this distorts the meaning of positive exponents in text strings, for example n = 103 is represented as n = 103. To preserve the meaning of exponents within text strings, superscript characters are identified using superscript HTML element markup, for example n = 10 <sup>3</sup>.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 22534,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Processing Table HTML ",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "Some publication tables contain content that could be represented in two or more separate tables. These multi-dimensional tables use the same gridlines, but new column headers are declared after initial column headers and data rows have appeared in the table. New column headers are identified by looking down columns and classifying each cell as one of three types: numerical, textual, and a mix of numbers and text. The type for a column is determined by the dominant cell type of all rows in a column excluding super rows. After the type of all columns are determined, the algorithm loops through all rows except super rows, and if more than half of cells in the row do not match with the columns' types, the row is identified as a new header row, and the rows that follow the new headers are then regarded as a sub-table. Auto-CORPus represents sub-tables as distinct tables in the table JSON, with identical metadata to the initial table. Tables are identified by the table number used in the publication, so since sub-tables will share their table number with the initial table, a new identifier is created for sub-tables with the initial table number, an underscore, then a sub-table number such as “1_1.”",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 23746,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Comparative Analysis of Outputs",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "The correspondence between PMC BioC and Auto-CORPus BioC outputs were compared to evaluate whether all information present in the PMC BioC output also appears in the Auto-CORPus BioC output. This was done by analyzing the number of characters in the PMC BioC JSON that appear in the same order in the Auto-CORPus BioC JSON using the longest common subsequence method. With this method, overlapping sequences of characters that vary in length are extracted from the PMC BioC string to find a matching sequence in the Auto-CORPus string. With this method it can occur that a subsequence from the PMC BioC matches to multiple parts of the Auto-CORPus BioC string (e.g., repeated words). This is mitigated by evaluating matches of overlapping/adjacent subsequences which should all be close to each other as they appear in the PMC BioC text.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 24614,
+          "infons": {
+            "section_title_1": "Materials and Methods",
+            "section_title_2": "Comparative Analysis of Outputs",
+            "iao_name_1": "materials section",
+            "iao_id_1": "IAO:0000633",
+            "iao_name_2": "methods section",
+            "iao_id_2": "IAO:0000317"
+          },
+          "text": "This longest common subsequence method was applied to each individual paragraph of the PMC BioC input and compared with the Auto-CORPus BioC paragraphs. This method was chosen over other string metric algorithms, such as the Levenshtein distance or cosine-similarity, due to it being non-symmetric/unidirectional (the Auto-CORPus BioC output strings contain more information (e.g., figure/table links, references) than the PMC BioC output) and ability to directly extract different characters.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 25107,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Data for the Evaluation of Algorithms",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "We attempted to download PMC BioC JSON format for all 1,200 GWAS PMC publications in our OA dataset, but only 766 were available as BioC from the NCBI server. We refer to this as the “PMC BioC dataset.” For the 766 PMC articles where we could obtain a NCBI BioC file, we processed the equivalent PMC HTML files using Auto-CORPus. We used only the BioC output files and refer to this as the “Auto-CORPus BioC dataset.” To compare the Auto-CORPus BioC and table outputs for PMC and publisher-specific versions, we accessed 163 Nature Communication and 5 Nature Genetics articles that overlap with the OA dataset and were not present in the publisher dataset, so they were unseen data. These journals have linked tables, so full-text and all linked table HTML files were accessed (367 linked table files). Auto-CORPus configuration files were setup for the journals to process the publisher-specific files and the BioC and table JSON output files were collated into what we refer to as the “linked table dataset.” The equivalent PMC HTML files from the OA dataset were also processed by Auto-CORPus and the BioC and table JSON files form the “inline table dataset.”",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 26313,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "The proportion of characters from 3,195 full-text paragraphs in the PMC BioC dataset that also appear in the Auto-CORPus BioC dataset in the same order in the paragraph string were evaluated using the longest common subsequence method. The median and interquartile range of the (left-skewed) similarity are 100% and 100–100%, respectively. Differences between the Auto-CORPus and PMC outputs are shown in Table 4 and relate to how display items, abbreviations and links are stored, and different character encodings. A structural difference between the two outputs is in how section titles are associated to passage text. In PMC BioC the section titles (and subtitles) are distinct from the passages they describe as both are treated as equivalent text. The section title occurs once in the file and the passage(s) it refers to follows it. In Auto-CORPus BioC the (first level) section titles (and subtitles) are linked directly with the passage text they refer to, and are included for each paragraph. Auto-CORPus uses IAO to classify text sections so, for example, the introduction title and text are grouped into a section annotated as introduction, rather than splitting these into two subsections (introduction title and introduction text as separate entities in the PMC BioC output) which would not fit with the IAO structure.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 27692,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "The Auto-CORPus BioC output includes the figure captions where they appear in the text and a separate table JSON file to store the table data, whereas the PMC BioC adds these data at the end of the JSON document and provides table content as a block of XML. Abbreviation sections are not included in the Auto-CORPus BioC output since Auto-CORPus provides a dedicated abbreviations JSON output. In the PMC BioC format the abbreviations and definitions are not related, whereas in the Auto-CORPus abbreviations JSON output the two elements are related. If an abbreviation does not contain a definition in the abbreviations section (perhaps due to an editorial error), PMC BioC will include the undefined thus meaningless abbreviation string, whereas Auto-CORPus will ignore it. Link anchor text to figures, tables, references and URLs are retained in the Auto-CORPus output but removed in the PMC BioC output. The most common differences between the two BioC versions is the encodings/strings used to reflect different whitespace characters and other special characters, with the remaining content being identical.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 28804,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "The proportion of characters from 9,468 full-text paragraphs in the publisher dataset that also appear in the Auto-CORPus PMC BioC dataset in the same order in the paragraph string were evaluated. The median and interquartile range of the (left-skewed) similarity is also 100 and 100–100%, respectively, and differences between the PMC and publisher-versions are the same as those previously observed and reported in Table 4.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 29229,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Full-Text Processing",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "Last, we evaluated the section title mapping to IAO terms for publication from non-biomedical domains (physics, psychology). We observed that not all publications from these domains have standardized headers that can be mapped directly or with fuzzy matching and require the digraph to map headers. Most headers are mapped correctly either to one or multiple (potential) IAO terms (Supplementary Table 1). Only one publication contained a mismatch where two sections were mapped to introduction and methods sections, respectively, where each of these contained sub-headers that relate to introduction, methods and results. In two physics publications we encountered the case where the “proportional to” sign (∝) could not be mapped by the encoder.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 29976,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Table Processing ",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "We assessed the accuracy of the table JSON output generated from non-PMC linked tables compared with table JSON output generated from the equivalent PMC HTML with inline tables. The comparative analysis method described above was used for comparing BioC output from the linked table and inline table datasets, except here it was applied to both strings (bidirectional, taking the maximum value of both outcomes). This is equivalent to the Levenshtein similarity applied to transform the larger string into the smaller string, with the exception that the different characters for both comparisons are retained for identifying the differences. The correspondence between table JSON files in the linked table and inline table datasets was calculated as the number of characters correctly represented in the publishers table JSON output relative to the PMC versions [also using the (symmetric) longest common subsequence method]. Both the text and table similarity are represented as the median (inter-quartile range) to account for non-normal distributions of the data. Any differences identified during these analyses were at the paragraph or table row level, enabling manual investigation of these sections in a side-by-side comparison of the files.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 31268,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Performance of Auto-CORPus Table Processing ",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "The proportion of characters from 367 tables in the linked table dataset that also appear in the inline table dataset in the same order in the cell or text string were evaluated. The median and interquartile range of the (left-skewed) similarity is 100 and 99.79–100.00%, respectively. We found that there were structural differences between some of the output files where additional data rows were present in the JSON files generated from the publisher's files. This occurred because cell value strings in tables from the publisher's files were split across two rows, however in the PMC version the string was formatted (wrapped) to be contained within a single row. The use of different table structures to contain the same data resulted in accurate but differing table JSON outputs. Most of the differences between table content and metadata values pertain to the character encoding used in the different table versions. For example, we have found different uses of hyphen/em dash/en dash/minus symbols between different versions, and Greek letters were represented differently in the different table versions. Other differences are related to how numbers are represented in scientific notation. If a cell contains a number only, then it is represented as a JSON number data type in the output. However, if the cell contains non-numeric characters, then there is no standardization of the cell text and the notation used (e.g., the × symbol or E notation) will be reproduced in the JSON output. When there is variation in notation between sources, the JSON outputs will differ. Other editorial differences include whether thousands are represented with or without commas and how whitespace characters are used. Despite these variations there was no information loss between processed inline and linked tables.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 33080,
+          "infons": {
+            "section_title_1": "Results",
+            "section_title_2": "Application: NER on GWAS Publications",
+            "iao_name_1": "results section",
+            "iao_id_1": "IAO:0000318"
+          },
+          "text": "Our intention is that Auto-CORPus supports information extraction from the biomedical literature. To demonstrate the use of Auto-CORPus outputs within a real-world application and aligned to the authors' expertise to support the evaluation of the results, we applied named-entity recognition (NER) to the Auto-CORPus BioC full-text output to extract GWAS metadata. Study metadata are included in curated GWAS databases, such as GWAS Central, and the ability to extract these entities automatically could provide a valuable curation aid. Full details of the method and the rationale behind the application is provided in the Supplementary Methods. In summary, we filtered out sentences in the methods sections from the BioC full-text output that contain information on the genotyping platforms, assays, total number of genetic variants, quality control and imputation that were used. We trained five separate algorithms for NER (one for each metadata type) using 700 GWAS publications and evaluated these on 500 GWAS publications of the test set. The F1-scores for the five tasks are between 0.82 and 1.00 (Supplementary Table 2) with examples given in Supplementary Figure 4.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 34292,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Strengths and Limitations",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "We have shown that Auto-CORPus brings together and bolsters several disjointed standards (BioC and IAO) and algorithmic components (for processing tables and abbreviations) of scientific literature analytics into a convenient and reliable tool for standardizing full-text and tables. The BioC format is a useful but not ubiquitous standard for representing text and annotations. Auto-CORPus enables the transformation of the widely available HTML format into BioC JSON following the setup of a configuration file associated with the structure of the HTML documents. The use of the configuration file drives the flexibility of the package, but also restricts use to users who are confident exploring HTML document structures. We make available the configuration files used in the evaluations described in this paper. To process additional sources, an upfront time investment is required from the user to explore the HTML structure and set the configuration file. We will be increasing the number of configuration files available for larger publishers, and we help non-technical users by providing documentation to explain how to setup configuration files. We welcome configuration files submitted by users and the documentation describes the process for users to submit files. Configuration files contain a section for tracking contributions made to the file, so the names of authors and editors can be logged. Once a configuration file has been submitted and tested, the file will be included within the Auto-CORPus package and the user credited (should they wish) with authorship of the file.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 35920,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Strengths and Limitations",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "The inclusion of IAO terms within the Auto-CORPus BioC output standardizes the description of publication sections across all processed sources. The digraph that is used to assign unmapped paragraph headers to standard IAO terms was constructed using both GWAS and MWAS literature to avoid training it to be used for a single domain only. We have tested the algorithms on PMC articles from three different physics and three psychology journals to confirm the BioC JSON output and IAO term recognition extend beyond only biomedical literature. Virtually all header terms from these articles were mapped to relevant IAO terms even when not all headers could be mapped, however some sections were mapped to multiple IAO terms based on paths in the digraph. Since ontologies are stable but not static, any resource or service that relies on one ontology structure could become outdated or redundant as the ontology is updated. We will rerun the fuzzy matching of headers to IAO terms and regenerate the digraph as new terms are introduced to the document part branch of IAO. We have experience of this when our first group of term suggestions based on the digraph were included into the IAO.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 37107,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Strengths and Limitations",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "The BioC output of abbreviations contains the abbreviation, definition and the algorithm(s) by which each pair was identified. One limitation of the current full-text abbreviation algorithm is that it searches for abbreviations in brackets and therefore will not find abbreviations for which the definition is in brackets, or abbreviations that are defined without use of brackets. The current structure of the abbreviation JSON allows additional methods to be included alongside the two methods currently used. Adding further algorithms to find different types of abbreviation in the full-text is considered as part of future work.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 37739,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Strengths and Limitations",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "Auto-CORPus implements a method for extracting table structures and data that was developed to extract table information from XML formatted tables (8). The use of the configuration file for identifying table containers enables the table processing to be focused on relevant data tables and exclude other tables associated with web page formatting. Auto-CORPus is distinct from other work in this field that uses machine learning methods to classify the types of information within tables (16). Auto-CORPus table processing is agnostic to the extracted variables, with the only distinction made between numbers and strings for the pragmatic reason of correctly formatting the JSON data type. The table JSON files could be used in downstream analysis (and annotation) of cell information types, but the intention of Auto-CORPus is to provide the capability to generate a faithful standardized output from any HTML source file. We have shown high accuracy (>99%) for the tables we have processed with a configuration file and the machine learning method was shown to recover data from ~86% of tables (16). Accurate extraction is possible across more data sources with the Auto-CORPus rule-based approach, but a greater investment in setup time is required.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 38992,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Strengths and Limitations",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "Auto-CORPus focuses on HTML versions of articles as these are readily and widely available within the biomedical domain. Currently the processing of PDF documents is not supported, but the work by the Semantic Scholar group to convert PDF documents to HTML is encouraging as they observed that 87% of PDF documents processed showed little to no readability issues (4). The ability to leverage reliable document transformation will have implications for processing supplementary information files and broader scientific literature sources which are sometimes only available in PDF format, and therefore will require conversion to the accessible and reusable HTML format.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 39661,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Future Research and Conclusions",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "We found that the tables for some publications are made available as images (see Table 1), so could not be processed by Auto-CORPus. To overcome this gap in publication table standardization, we are refining a plugin for Auto-CORPus that provides an algorithm for processing images of tables. The algorithm leverages Google's Tesseract optical character recognition engine to extract text from preprocessed table images. An overview of the table image processing pipeline is available in Supplementary Figure 3. During our preliminary evaluation of the plugin, it achieved an accuracy of ~88% when processing a collection of 200 JPG and PNG table images taken from 23 different journals. Although encouraging, there are caveats in that the image formats must be of high resolution, the algorithm performs better on tables with gridlines than tables without gridlines, special characters are rarely interpreted correctly, and cell text formatting is lost. We are fine tuning the Tesseract model by training new datasets on biomedical data. An alpha release of the table image processing plugin is available with the Auto-CORPus package.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 40827,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Future Research and Conclusions",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "The authors are involved in omics health data NLP projects that use Auto-CORPus within text mining pipelines to standardize and optimize biomedical literature ahead of entity and relation annotations and have given examples in the Supplementary Material of how the Auto-CORPus output was used to train these algorithms. The BioC format supports the stand-off annotation of linguistic features such as tokens, part-of-speech tags and noun phrases, as well as the annotation of relations between these elements (5). We are developing machine learning methods to automatically extract genome-wide association study (GWAS) data from peer-reviewed literature. High quality annotated datasets are required to develop and train NLP algorithms and validate the outputs. We are developing a GWAS corpus that can be used for this purpose using a semi-automated annotation method. The GWAS Central database is a comprehensive collection of summary-level GWAS findings imported from published research papers or submitted by study authors (13). For GWAS Central studies, we used Auto-CORPus to standardize the full-text publication text and tables. In an automatic annotation step, for each publication, all GWAS Central association data was retrieved. Association data consists of three related entities: a phenotype/disease description, genetic marker, and an association P-value. A named entity recognition algorithm identifies the database entities in the Auto-CORPus BioC and table JSON files. The database entities and relations are mapped back onto the text, by expressing the annotations in BioC format and appending these to the relevant BioC element in the JSON files. The automatic annotations are then manually evaluated using the TeamTat text annotation tool which provides a user-friendly interface for annotating entities and relations (17). We use TeamTat to manually inspect the automatic annotations and modify or remove incorrect annotations, in addition to including new annotations that were not automatically generated. TeamTat accepts BioC input files and outputs in BioC format, thus the Auto-CORPus files that have been automatically annotated are suitable for importing into TeamTat. Work to create the GWAS corpus is ongoing, but the convenient semi-automatic process for creating high-quality annotations from biomedical literature HTML files described here could be adapted for creating other gold-standard corpora.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 43259,
+          "infons": {
+            "section_title_1": "Discussion",
+            "section_title_2": "Future Research and Conclusions",
+            "iao_name_1": "discussion section",
+            "iao_id_1": "IAO:0000319"
+          },
+          "text": "In related work, we are developing a corpus for MWAS for metabolite named-entity recognition to enable the development of new NLP tools to speed up literature review. As part of this, the active development focuses on extending Auto-CORPus to analyse preprint literature and Supplementary Materials, improving the abbreviation detection, and development of more configuration files. Our preliminary work on preprint literature has shown we can map paragraphs in Rxiv versions to paragraphs in the peer-reviewed manuscript with the high accuracy (average similarity of paragraphs >95%). Another planned extension is to classify paragraphs based on the text in the case where headers are mapped to multiple IAO terms. The flexibility of the Auto-CORPus configuration file enables researchers to use Auto-CORPus to process publications and data from a broad variety of sources to create reusable corpora for many use cases in biomedical literature and other scientific fields.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 44232,
+          "infons": {
+            "section_title_1": "Author Contributions",
+            "iao_name_1": "author contributions section",
+            "iao_id_1": "IAO:0000323"
+          },
+          "text": "TB and JP designed and supervised the research and wrote the manuscript. TB contributed the GWAS use case and JP contributed the MWAS/metabolomics use cases. TS developed the BioC outputs and led the coding integration aspects. YH developed the section header standardization algorithm and implemented the abbreviation recognition algorithm. ZL developed the table image recognition and processing algorithm. SS developed the table extraction algorithm and main configuration file. CP developed configuration files for preprint texts. NM developed the NER algorithms for GWAS entity recognition. NM, FM, CY, ZL, and CP tested the package and performed comparative analysis of outputs. TR refined standardization of full-texts and contributed algorithms for character set conversions. All authors read, edited, and approved the manuscript.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 45090,
+          "infons": {
+            "section_title_1": "Funding",
+            "iao_name_1": "funding source declaration section",
+            "iao_id_1": "IAO:0000623"
+          },
+          "text": "This work has been supported by Health Data Research (HDR) UK and the Medical Research Council via an UKRI Innovation Fellowship to TB (MR/S003703/1) and a Rutherford Fund Fellowship to JP (MR/S004033/1).",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 45301,
+          "infons": {
+            "section_title_1": "Conflict of Interest",
+            "iao_name_1": "conflict of interest section",
+            "iao_id_1": "IAO:0000616"
+          },
+          "text": "The authors declare that the research was conducted in the absence of any commercial or financial relationships that could be construed as a potential conflict of interest.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 45493,
+          "infons": {
+            "section_title_1": "Publisher's Note",
+            "iao_name_1": "notes section",
+            "iao_id_1": "IAO:0000634"
+          },
+          "text": "All claims expressed in this article are solely those of the authors and do not necessarily represent those of their affiliated organizations, or those of the publisher, the editors and the reviewers. Any product that may be evaluated in this article, or claim that may be made by its manufacturer, is not guaranteed or endorsed by the publisher.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 45855,
+          "infons": {
+            "section_title_1": "Acknowledgments",
+            "iao_name_1": "acknowledgements section",
+            "iao_id_1": "IAO:0000324"
+          },
+          "text": "We thank Mohamed Ibrahim (University of Leicester) for identifying different configurations of tables for different HTML formats.",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 45999,
+          "infons": {
+            "section_title_1": "Supplementary Material",
+            "iao_name_1": "supplementary material section",
+            "iao_id_1": "IAO:0000326"
+          },
+          "text": "The Supplementary Material for this article can be found online at: https://www.frontiersin.org/articles/10.3389/fdgth.2022.788124/full#supplementary-material",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 46179,
+          "infons": {
+            "title": "Natural language processing of clinical notes on chronic diseases: systematic review",
+            "journal": "JMIR Med Inform.",
+            "volume": "7",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "1. Sheikhalishahi S, Miotto R, Dudley JT, Lavelli A, Rinaldi F, Osmani V. Natural language processing of clinical notes on chronic diseases: systematic review. JMIR Med Inform. (2019) 7:e12239. 10.2196/12239 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 46452,
+          "infons": {
+            "title": "Natural language processing to extract symptoms of severe mental illness from clinical text: the Clinical Record Interactive Search Comprehensive Data Extraction (CRIS-CODE) project",
+            "journal": "BMJ Open",
+            "volume": "7",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "2. Jackson RG, Patel R, Jayatilleke N, Kolliakou A, Ball M, Gorrell G, et al.. Natural language processing to extract symptoms of severe mental illness from clinical text: the Clinical Record Interactive Search Comprehensive Data Extraction (CRIS-CODE) project. BMJ Open. (2017) 7:e012012. 10.1136/bmjopen-2016-012012 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 46825,
+          "infons": {
+            "title": "Status of text-mining techniques applied to biomedical text",
+            "journal": "Drug Discov Today.",
+            "volume": "11",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "3. Erhardt RA, Schneider R, Blaschke C. Status of text-mining techniques applied to biomedical text. Drug Discov Today. (2006) 11:315–25. 10.1016/j.drudis.2006.02.011 [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 47028,
+          "infons": {
+            "title": "Improving the accessibility of scientific documents: current state, user needs, and a system solution to enhance scientific PDF accessibility for blind and low vision users",
+            "journal": "arXiv e-prints: arXiv:2105.00076",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "4. Wang LL, Cachola I, Bragg J, Yu-Yen Cheng E, Haupt C, Latzke M, et al.. Improving the accessibility of scientific documents: current state, user needs, and a system solution to enhance scientific PDF accessibility for blind and low vision users. arXiv e-prints: arXiv:2105.00076 (2021). Available online at: https://arxiv.org/pdf/2105.00076.pdf",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 47375,
+          "infons": {
+            "title": "BioC: a minimalist approach to interoperability for biomedical text processing",
+            "journal": "Database.",
+            "volume": "2013",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "5. Comeau DC, Islamaj Dogan R, Ciccarese P, Cohen KB, Krallinger M, Leitner F, et al.. BioC: a minimalist approach to interoperability for biomedical text processing. Database. (2013) 2013:bat064. 10.1093/database/bat064 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 47651,
+          "infons": {
+            "title": "PMC text mining subset in BioC: about three million full-text articles and growing",
+            "journal": "Bioinformatics.",
+            "volume": "35",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "6. Comeau DC, Wei CH, Islamaj Dogan R, Lu Z. PMC text mining subset in BioC: about three million full-text articles and growing. Bioinformatics. (2019) 35:3533–5. 10.1093/bioinformatics/btz070 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 47899,
+          "infons": {
+            "title": "An information artifact ontology perspective on data collections and associated representational artifacts",
+            "journal": "Stud Health Technol Inform.",
+            "volume": "180",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "7. Ceusters W. An information artifact ontology perspective on data collections and associated representational artifacts. Stud Health Technol Inform. (2012) 180:68–72. 10.3233/978-1-61499-101-4-68 [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 48133,
+          "infons": {
+            "title": "Disentangling the structure of tables in scientific literature",
+            "journal": "Natural Language Processing and Information Systems",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "8. Milosevic N, Gregson C, Hernandez R, Nenadic G. Disentangling the structure of tables in scientific literature. In: Métais E, Meziane F, Saraee M, Sugumaran V, Vadera S, editors. Natural Language Processing and Information Systems. Cham: Springer International Publishing; (2016). p. 162–74. 10.1007/978-3-319-41754-7_14 [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 48484,
+          "infons": {
+            "title": "Constructing biological knowledge bases by extracting information from text sources",
+            "journal": "International Conference on Intelligent Systems for Molecular Biology.",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "9. Craven M, Kumlien J. Constructing biological knowledge bases by extracting information from text sources. In: International Conference on Intelligent Systems for Molecular Biology.Heidelberg: (1999) p. 77–86. [PubMed] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 48721,
+          "infons": {
+            "title": "Automatic extraction of biological information from scientific text: protein-protein interactions",
+            "journal": "International Conference on Intelligent Systems for Molecular Biology",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "10. Blaschke C, Andrade MA, Ouzounis C, Valencia A. Automatic extraction of biological information from scientific text: protein-protein interactions. In: International Conference on Intelligent Systems for Molecular Biology. Heidelberg: (1999) p. 60–7. [PubMed] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 49000,
+          "infons": {
+            "title": "Automatic annotation for biological sequences by extraction of keywords from MEDLINE abstracts. Development of a prototype system",
+            "journal": "Proc Int Conf Intell Syst Mol Biol.",
+            "volume": "5",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "11. Andrade MA, Valencia A. Automatic annotation for biological sequences by extraction of keywords from MEDLINE abstracts. Development of a prototype system. Proc Int Conf Intell Syst Mol Biol. (1997) 5:25–32. [PubMed] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 49236,
+          "infons": {
+            "title": "A simple algorithm for identifying abbreviation definitions in biomedical text",
+            "journal": "Pac Symp Biocomput.",
+            "volume": "8",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "12. Schwartz AS, Hearst MA. A simple algorithm for identifying abbreviation definitions in biomedical text. Pac Symp Biocomput. (2003) 8:451–62. Available online at: https://psb.stanford.edu/psb-online/proceedings/psb03/schwartz.pdf [PubMed] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 49494,
+          "infons": {
+            "title": "GWAS Central: a comprehensive resource for the discovery and comparison of genotype and phenotype data from genome-wide association studies",
+            "journal": "Nucleic Acids Res",
+            "volume": "48",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "13. Beck T, Shorter T, Brookes AJ. GWAS Central: a comprehensive resource for the discovery and comparison of genotype and phenotype data from genome-wide association studies. Nucleic Acids Res. (2020) 48:D933–40. 10.1093/nar/gkz895 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 49782,
+          "infons": {
+            "title": "Creating mappings for ontologies in biomedicine: simple methods work",
+            "journal": "AMIA Annu Symp Proc.",
+            "volume": "2009",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "14. Ghazvinian A, Noy NF, Musen MA. Creating mappings for ontologies in biomedicine: simple methods work. AMIA Annu Symp Proc. (2009) 2009:198–202. [PMC free article] [PubMed] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 49974,
+          "infons": {
+            "title": "Trans-ethnic meta-analysis of white blood cell phenotypes",
+            "journal": "Hum Mol Genet.",
+            "volume": "23",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "15. Keller MF, Reiner AP, Okada Y, van Rooij FJ, Johnson AD, Chen MH, et al.. Trans-ethnic meta-analysis of white blood cell phenotypes. Hum Mol Genet. (2014) 23:6944–60. 10.1093/hmg/ddu401 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 50219,
+          "infons": {
+            "title": "A framework for information extraction from tables in biomedical literature",
+            "journal": "Int J Docum Anal Recogn.",
+            "volume": "22",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "16. Milosevic N, Gregson C, Hernandez R, Nenadic G. A framework for information extraction from tables in biomedical literature. Int J Docum Anal Recogn. (2019) 22:55–78. 10.1007/s10032-019-00317-0 [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
+        },
+        {
+          "offset": 50444,
+          "infons": {
+            "title": "TeamTat: a collaborative text annotation tool",
+            "journal": "Nucleic Acids Res",
+            "volume": "48",
+            "section_title_1": "References",
+            "iao_name_1": "references section",
+            "iao_id_1": "IAO:0000320"
+          },
+          "text": "17. Islamaj R, Kwon D, Kim S, Lu Z. TeamTat: a collaborative text annotation tool. Nucleic Acids Res. (2020) 48:W5–11. 10.1093/nar/gkaa333 [PMC free article] [PubMed] [CrossRef] [Google Scholar]",
+          "sentences": [],
+          "annotations": [],
+          "relations": []
         }
-    ]
+      ],
+      "annotations": [],
+      "relations": []
+    }
+  ]
 }

--- a/tests/data/PMC8885717_tables.json
+++ b/tests/data/PMC8885717_tables.json
@@ -1,1482 +1,1482 @@
 {
-    "source": "Auto-CORPus (tables)",
-    "date": "20240829",
-    "key": "autocorpus_tables.key",
-    "infons": {},
-    "documents": [
+  "source": "Auto-CORPus (tables)",
+  "date": "20240829",
+  "key": "autocorpus_tables.key",
+  "infons": {},
+  "documents": [
+    {
+      "inputfile": "tests/data/PMC8885717.html",
+      "id": "1",
+      "infons": {},
+      "passages": [
         {
-            "inputfile": "tests/data/PMC8885717.html",
-            "id": "1",
-            "infons": {},
-            "passages": [
-                {
-                    "offset": 0,
-                    "infons": {
-                        "section_title_1": "table_title",
-                        "iao_name_1": "document title",
-                        "iao_id_1": "IAO:0000305"
-                    },
-                    "text": [
-                        "Table 1"
-                    ]
-                },
-                {
-                    "offset": 1,
-                    "infons": {
-                        "section_title_1": "table_caption",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "Publishers and journals included in the publisher dataset."
-                },
-                {
-                    "offset": 59,
-                    "infons": {
-                        "section_title_1": "table_content",
-                        "iao_name_1": "table",
-                        "iao_id_1": "IAO:0000306"
-                    },
-                    "column_headings": [
-                        {
-                            "cell_id": "1.1.1",
-                            "cell_text": "Publisher"
-                        },
-                        {
-                            "cell_id": "1.1.2",
-                            "cell_text": "Journal"
-                        },
-                        {
-                            "cell_id": "1.1.3",
-                            "cell_text": "Number of full-text files"
-                        },
-                        {
-                            "cell_id": "1.1.4",
-                            "cell_text": "Overlap with OA dataset"
-                        },
-                        {
-                            "cell_id": "1.1.5",
-                            "cell_text": "Table type"
-                        },
-                        {
-                            "cell_id": "1.1.6",
-                            "cell_text": "Number of table files"
-                        }
-                    ],
-                    "data_section": [
-                        {
-                            "table_section_title_1": "",
-                            "data_rows": [
-                                [
-                                    {
-                                        "cell_id": "1.2.1",
-                                        "cell_text": "American Heart Association"
-                                    },
-                                    {
-                                        "cell_id": "1.2.2",
-                                        "cell_text": "Circulation Cardiovascular Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.2.3",
-                                        "cell_text": 52.0
-                                    },
-                                    {
-                                        "cell_id": "1.2.4",
-                                        "cell_text": 39.0
-                                    },
-                                    {
-                                        "cell_id": "1.2.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.2.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.3.1",
-                                        "cell_text": "American Physical Society"
-                                    },
-                                    {
-                                        "cell_id": "1.3.2",
-                                        "cell_text": "Physical Review Letters<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.3.3",
-                                        "cell_text": 6.0
-                                    },
-                                    {
-                                        "cell_id": "1.3.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.3.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.3.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.4.1",
-                                        "cell_text": "American Psychological Association"
-                                    },
-                                    {
-                                        "cell_id": "1.4.2",
-                                        "cell_text": "Psychological Bulletin<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.4.3",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.4.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.4.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.4.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.5.1",
-                                        "cell_text": "American Society of Hematology"
-                                    },
-                                    {
-                                        "cell_id": "1.5.2",
-                                        "cell_text": "Blood"
-                                    },
-                                    {
-                                        "cell_id": "1.5.3",
-                                        "cell_text": 31.0
-                                    },
-                                    {
-                                        "cell_id": "1.5.4",
-                                        "cell_text": 25.0
-                                    },
-                                    {
-                                        "cell_id": "1.5.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.5.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.6.1",
-                                        "cell_text": "American Thoracic Society"
-                                    },
-                                    {
-                                        "cell_id": "1.6.2",
-                                        "cell_text": "American Journal of Respiratory and Critical Care Medicine"
-                                    },
-                                    {
-                                        "cell_id": "1.6.3",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.6.4",
-                                        "cell_text": 18.0
-                                    },
-                                    {
-                                        "cell_id": "1.6.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.6.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.7.1",
-                                        "cell_text": "BioMed Central"
-                                    },
-                                    {
-                                        "cell_id": "1.7.2",
-                                        "cell_text": "BMC Medical Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.7.3",
-                                        "cell_text": 43.0
-                                    },
-                                    {
-                                        "cell_id": "1.7.4",
-                                        "cell_text": 43.0
-                                    },
-                                    {
-                                        "cell_id": "1.7.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.7.6",
-                                        "cell_text": 160.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.8.1",
-                                        "cell_text": "Cell Press"
-                                    },
-                                    {
-                                        "cell_id": "1.8.2",
-                                        "cell_text": "American Journal of Human Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.8.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.8.4",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.8.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.8.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.9.1",
-                                        "cell_text": "Elsevier"
-                                    },
-                                    {
-                                        "cell_id": "1.9.2",
-                                        "cell_text": "Biological Psychiatry"
-                                    },
-                                    {
-                                        "cell_id": "1.9.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.9.4",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.9.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.9.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.10.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.10.2",
-                                        "cell_text": "Gastroenterology"
-                                    },
-                                    {
-                                        "cell_id": "1.10.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.10.4",
-                                        "cell_text": 2.0
-                                    },
-                                    {
-                                        "cell_id": "1.10.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.10.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.11.1",
-                                        "cell_text": "Frontiers"
-                                    },
-                                    {
-                                        "cell_id": "1.11.2",
-                                        "cell_text": "Frontiers in Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.11.3",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.11.4",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.11.5",
-                                        "cell_text": "Linked images"
-                                    },
-                                    {
-                                        "cell_id": "1.11.6",
-                                        "cell_text": "n/a"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.12.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.12.2",
-                                        "cell_text": "Frontiers in Physics<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.12.3",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.12.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.12.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.12.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.13.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.13.2",
-                                        "cell_text": "Frontiers in Psychology<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.13.3",
-                                        "cell_text": 4.0
-                                    },
-                                    {
-                                        "cell_id": "1.13.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.13.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.13.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.14.1",
-                                        "cell_text": "Massachusetts Medical Society"
-                                    },
-                                    {
-                                        "cell_id": "1.14.2",
-                                        "cell_text": "The New England Journal of Medicine"
-                                    },
-                                    {
-                                        "cell_id": "1.14.3",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.14.4",
-                                        "cell_text": 12.0
-                                    },
-                                    {
-                                        "cell_id": "1.14.5",
-                                        "cell_text": "Linked images"
-                                    },
-                                    {
-                                        "cell_id": "1.14.6",
-                                        "cell_text": "n/a"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.15.1",
-                                        "cell_text": "Mosby"
-                                    },
-                                    {
-                                        "cell_id": "1.15.2",
-                                        "cell_text": "The Journal of Allergy and Clinical Immunology"
-                                    },
-                                    {
-                                        "cell_id": "1.15.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.15.4",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.15.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.15.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.16.1",
-                                        "cell_text": "Nature Portfolio"
-                                    },
-                                    {
-                                        "cell_id": "1.16.2",
-                                        "cell_text": "European Journal of Human Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.16.3",
-                                        "cell_text": 50.0
-                                    },
-                                    {
-                                        "cell_id": "1.16.4",
-                                        "cell_text": 50.0
-                                    },
-                                    {
-                                        "cell_id": "1.16.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.16.6",
-                                        "cell_text": 123.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.17.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.17.2",
-                                        "cell_text": "Journal of Human Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.17.3",
-                                        "cell_text": 37.0
-                                    },
-                                    {
-                                        "cell_id": "1.17.4",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.17.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.17.6",
-                                        "cell_text": 90.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.18.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.18.2",
-                                        "cell_text": "Molecular Psychiatry"
-                                    },
-                                    {
-                                        "cell_id": "1.18.3",
-                                        "cell_text": 103.0
-                                    },
-                                    {
-                                        "cell_id": "1.18.4",
-                                        "cell_text": 78.0
-                                    },
-                                    {
-                                        "cell_id": "1.18.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.18.6",
-                                        "cell_text": 262.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.19.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.19.2",
-                                        "cell_text": "Nature Physics<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.19.3",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.19.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.19.5",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.19.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.20.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.20.2",
-                                        "cell_text": "Scientific Reports"
-                                    },
-                                    {
-                                        "cell_id": "1.20.3",
-                                        "cell_text": 80.0
-                                    },
-                                    {
-                                        "cell_id": "1.20.4",
-                                        "cell_text": 80.0
-                                    },
-                                    {
-                                        "cell_id": "1.20.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.20.6",
-                                        "cell_text": 190.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.21.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.21.2",
-                                        "cell_text": "The Pharmacogenomics Journal"
-                                    },
-                                    {
-                                        "cell_id": "1.21.3",
-                                        "cell_text": 37.0
-                                    },
-                                    {
-                                        "cell_id": "1.21.4",
-                                        "cell_text": 16.0
-                                    },
-                                    {
-                                        "cell_id": "1.21.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.21.6",
-                                        "cell_text": 116.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.22.1",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.22.2",
-                                        "cell_text": "Translational Psychiatry"
-                                    },
-                                    {
-                                        "cell_id": "1.22.3",
-                                        "cell_text": 41.0
-                                    },
-                                    {
-                                        "cell_id": "1.22.4",
-                                        "cell_text": 41.0
-                                    },
-                                    {
-                                        "cell_id": "1.22.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.22.6",
-                                        "cell_text": 87.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.23.1",
-                                        "cell_text": "Oxford University Press"
-                                    },
-                                    {
-                                        "cell_id": "1.23.2",
-                                        "cell_text": "Human Molecular Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.23.3",
-                                        "cell_text": 254.0
-                                    },
-                                    {
-                                        "cell_id": "1.23.4",
-                                        "cell_text": 186.0
-                                    },
-                                    {
-                                        "cell_id": "1.23.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.23.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.24.1",
-                                        "cell_text": "PLOS"
-                                    },
-                                    {
-                                        "cell_id": "1.24.2",
-                                        "cell_text": "PLOS One"
-                                    },
-                                    {
-                                        "cell_id": "1.24.3",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.24.4",
-                                        "cell_text": 20.0
-                                    },
-                                    {
-                                        "cell_id": "1.24.5",
-                                        "cell_text": "Linked images"
-                                    },
-                                    {
-                                        "cell_id": "1.24.6",
-                                        "cell_text": "n/a"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.25.1",
-                                        "cell_text": "SAGE Publications"
-                                    },
-                                    {
-                                        "cell_id": "1.25.2",
-                                        "cell_text": "Psychological Science<sup>a</sup>"
-                                    },
-                                    {
-                                        "cell_id": "1.25.3",
-                                        "cell_text": 3.0
-                                    },
-                                    {
-                                        "cell_id": "1.25.4",
-                                        "cell_text": "\u2013"
-                                    },
-                                    {
-                                        "cell_id": "1.25.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.25.6",
-                                        "cell_text": "-"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.26.1",
-                                        "cell_text": "Springer"
-                                    },
-                                    {
-                                        "cell_id": "1.26.2",
-                                        "cell_text": "Human Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.26.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.26.4",
-                                        "cell_text": 2.0
-                                    },
-                                    {
-                                        "cell_id": "1.26.5",
-                                        "cell_text": "Linked HTML"
-                                    },
-                                    {
-                                        "cell_id": "1.26.6",
-                                        "cell_text": 13.0
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.27.1",
-                                        "cell_text": "Wiley-Blackwell"
-                                    },
-                                    {
-                                        "cell_id": "1.27.2",
-                                        "cell_text": "American Journal of Medical Genetics"
-                                    },
-                                    {
-                                        "cell_id": "1.27.3",
-                                        "cell_text": 5.0
-                                    },
-                                    {
-                                        "cell_id": "1.27.4",
-                                        "cell_text": 0.0
-                                    },
-                                    {
-                                        "cell_id": "1.27.5",
-                                        "cell_text": "Inline"
-                                    },
-                                    {
-                                        "cell_id": "1.27.6",
-                                        "cell_text": "\u2013"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "1.28.1",
-                                        "cell_text": "Total"
-                                    },
-                                    {
-                                        "cell_id": "1.28.2",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.28.3",
-                                        "cell_text": 860.0
-                                    },
-                                    {
-                                        "cell_id": "1.28.4",
-                                        "cell_text": 648.0
-                                    },
-                                    {
-                                        "cell_id": "1.28.5",
-                                        "cell_text": ""
-                                    },
-                                    {
-                                        "cell_id": "1.28.6",
-                                        "cell_text": 1041.0
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "offset": 1542,
-                    "infons": {
-                        "section_title_1": "table_footer",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "The full-text files were downloaded in HTML format and the linked table files were downloaded when available in HTML formats. The full-text files that overlap with the OA dataset were used to assess the consistency of outputs generated from different sources.<sup>a</sup>These publications are not part of the publisher dataset for evaluating tables, but are used for evaluating the accuracy of IAO header mapping."
-                }
-            ]
+          "offset": 0,
+          "infons": {
+            "section_title_1": "table_title",
+            "iao_name_1": "document title",
+            "iao_id_1": "IAO:0000305"
+          },
+          "text": [
+            "Table 1"
+          ]
         },
         {
-            "inputfile": "tests/data/PMC8885717.html",
-            "id": "2",
-            "infons": {},
-            "passages": [
-                {
-                    "offset": 0,
-                    "infons": {
-                        "section_title_1": "table_title",
-                        "iao_name_1": "document title",
-                        "iao_id_1": "IAO:0000305"
-                    },
-                    "text": [
-                        "Table 2"
-                    ]
-                },
-                {
-                    "offset": 1,
-                    "infons": {
-                        "section_title_1": "table_caption",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "New synonyms identified for existing IAO terms from the fuzzy and digraph mappings of 2,441 publications."
-                },
-                {
-                    "offset": 106,
-                    "infons": {
-                        "section_title_1": "table_content",
-                        "iao_name_1": "table",
-                        "iao_id_1": "IAO:0000306"
-                    },
-                    "column_headings": [
-                        {
-                            "cell_id": "2.1.1",
-                            "cell_text": "Category (IAO identifier)"
-                        },
-                        {
-                            "cell_id": "2.1.2",
-                            "cell_text": "Existing synonyms<sup>a</sup>"
-                        },
-                        {
-                            "cell_id": "2.1.3",
-                            "cell_text": "New synonyms identified<sup>b</sup>"
-                        }
-                    ],
-                    "data_section": [
-                        {
-                            "table_section_title_1": "",
-                            "data_rows": [
-                                [
-                                    {
-                                        "cell_id": "2.2.1",
-                                        "cell_text": "abbreviations (IAO:0000606)"
-                                    },
-                                    {
-                                        "cell_id": "2.2.2",
-                                        "cell_text": "abbreviations, abbreviations list, abbreviations used, list of abbreviations, list of abbreviations used"
-                                    },
-                                    {
-                                        "cell_id": "2.2.3",
-                                        "cell_text": "abbreviation and acronyms, abbreviation list, abbreviations and acronyms, abbreviations used in this paper, definitions for abbreviations, glossary, key abbreviations, non-standard abbreviations, nonstandard abbreviations, nonstandard abbreviations and acronyms"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.3.1",
-                                        "cell_text": "abstract (IAO:0000315)"
-                                    },
-                                    {
-                                        "cell_id": "2.3.2",
-                                        "cell_text": "abstract"
-                                    },
-                                    {
-                                        "cell_id": "2.3.3",
-                                        "cell_text": "precis"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.4.1",
-                                        "cell_text": "acknowledgments (IAO:0000324)"
-                                    },
-                                    {
-                                        "cell_id": "2.4.2",
-                                        "cell_text": "acknowledgments, acknowledgments"
-                                    },
-                                    {
-                                        "cell_id": "2.4.3",
-                                        "cell_text": "acknowledgment, acknowledgment, acknowledgments and disclaimer"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.5.1",
-                                        "cell_text": "author contributions (IAO:0000323)"
-                                    },
-                                    {
-                                        "cell_id": "2.5.2",
-                                        "cell_text": "author contributions, contributions by the authors"
-                                    },
-                                    {
-                                        "cell_id": "2.5.3",
-                                        "cell_text": "authors' contribution, authors' contributions, authors' roles, contributorship, main authors by consortium and author contributions"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.6.1",
-                                        "cell_text": "author information (IAO:0000607)"
-                                    },
-                                    {
-                                        "cell_id": "2.6.2",
-                                        "cell_text": "author information, authors' information"
-                                    },
-                                    {
-                                        "cell_id": "2.6.3",
-                                        "cell_text": "biographies, contributor information"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.7.1",
-                                        "cell_text": "availability (IAO:0000611)"
-                                    },
-                                    {
-                                        "cell_id": "2.7.2",
-                                        "cell_text": "availability, availability and requirements"
-                                    },
-                                    {
-                                        "cell_id": "2.7.3",
-                                        "cell_text": "availability of data, availability of data and materials, data archiving, data availability, data availability statement, data sharing statement"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.8.1",
-                                        "cell_text": "conclusion (IAO:0000615)"
-                                    },
-                                    {
-                                        "cell_id": "2.8.2",
-                                        "cell_text": "concluding remarks, conclusion, conclusions, findings, summary"
-                                    },
-                                    {
-                                        "cell_id": "2.8.3",
-                                        "cell_text": "conclusion and perspectives, summary and conclusion"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.9.1",
-                                        "cell_text": "conflict of interest (IAO:0000616)"
-                                    },
-                                    {
-                                        "cell_id": "2.9.2",
-                                        "cell_text": "competing interests, conflict of interest, conflict of interest statement, declaration of competing interests, disclosure of potential conflicts of interest"
-                                    },
-                                    {
-                                        "cell_id": "2.9.3",
-                                        "cell_text": "authors' disclosures of potential conflicts of interest, competing financial interests, conflict of interests, conflicts of interest, declaration of competing interest, declaration of interest, declaration of interests, disclosure of conflict of interest, duality of interest, statement of interest"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.10.1",
-                                        "cell_text": "consent (IAO:0000618)"
-                                    },
-                                    {
-                                        "cell_id": "2.10.2",
-                                        "cell_text": "consent"
-                                    },
-                                    {
-                                        "cell_id": "2.10.3",
-                                        "cell_text": "Informed consent"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.11.1",
-                                        "cell_text": "discussion (IAO:0000319)"
-                                    },
-                                    {
-                                        "cell_id": "2.11.2",
-                                        "cell_text": "discussion, discussion section"
-                                    },
-                                    {
-                                        "cell_id": "2.11.3",
-                                        "cell_text": "discussions"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.12.1",
-                                        "cell_text": "ethical approval (IAO:0000620)"
-                                    },
-                                    {
-                                        "cell_id": "2.12.2",
-                                        "cell_text": "ethical approval"
-                                    },
-                                    {
-                                        "cell_id": "2.12.3",
-                                        "cell_text": "ethics approval and consent to participate, ethical requirements, ethics, ethics statement"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.13.1",
-                                        "cell_text": "footnote (IAO:0000325)"
-                                    },
-                                    {
-                                        "cell_id": "2.13.2",
-                                        "cell_text": "endnote, footnote"
-                                    },
-                                    {
-                                        "cell_id": "2.13.3",
-                                        "cell_text": "footnotes"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.14.1",
-                                        "cell_text": "funding source declaration (IAO:0000623)"
-                                    },
-                                    {
-                                        "cell_id": "2.14.2",
-                                        "cell_text": "funding, funding information, funding sources, funding statement, funding/support, source of funding, sources of funding"
-                                    },
-                                    {
-                                        "cell_id": "2.14.3",
-                                        "cell_text": "financial support, grants, role of the funding source, study funding"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.15.1",
-                                        "cell_text": "future directions (IAO:0000625)"
-                                    },
-                                    {
-                                        "cell_id": "2.15.2",
-                                        "cell_text": "future challenges, future considerations, future developments, future directions, future outlook, future perspectives, future plans, future prospects, future research, future research directions, future studies, future work"
-                                    },
-                                    {
-                                        "cell_id": "2.15.3",
-                                        "cell_text": "outlook"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.16.1",
-                                        "cell_text": "introduction (IAO:0000316)"
-                                    },
-                                    {
-                                        "cell_id": "2.16.2",
-                                        "cell_text": "background, introduction"
-                                    },
-                                    {
-                                        "cell_id": "2.16.3",
-                                        "cell_text": "introductory paragraph"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.17.1",
-                                        "cell_text": "materials (IAO:0000633)"
-                                    },
-                                    {
-                                        "cell_id": "2.17.2",
-                                        "cell_text": "materials"
-                                    },
-                                    {
-                                        "cell_id": "2.17.3",
-                                        "cell_text": "data, data description"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.18.1",
-                                        "cell_text": "methods (IAO:0000317)"
-                                    },
-                                    {
-                                        "cell_id": "2.18.2",
-                                        "cell_text": "experimental, experimental procedures, experimental section, materials and methods, methods"
-                                    },
-                                    {
-                                        "cell_id": "2.18.3",
-                                        "cell_text": "analytical methods, concise methods, experimental methods, method, method validation, methodology, methods and design, methods and procedures, methods and tools, methods/design, online methods, star methods, study design, study design and methods"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.19.1",
-                                        "cell_text": "references (IAO:0000320)"
-                                    },
-                                    {
-                                        "cell_id": "2.19.2",
-                                        "cell_text": "bibliography, literature cited, references"
-                                    },
-                                    {
-                                        "cell_id": "2.19.3",
-                                        "cell_text": "literature cited, reference, references, reference list, selected references, web site references"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.20.1",
-                                        "cell_text": "statistical analysis (IAO:0000644)"
-                                    },
-                                    {
-                                        "cell_id": "2.20.2",
-                                        "cell_text": "statistical analysis"
-                                    },
-                                    {
-                                        "cell_id": "2.20.3",
-                                        "cell_text": "statistical methods, statistical methods and analysis, statistics"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.21.1",
-                                        "cell_text": "study limitations (IAO:0000631)"
-                                    },
-                                    {
-                                        "cell_id": "2.21.2",
-                                        "cell_text": "limitations, study limitations"
-                                    },
-                                    {
-                                        "cell_id": "2.21.3",
-                                        "cell_text": "strengths and limitations, study strengths and limitations"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "2.22.1",
-                                        "cell_text": "supplementary material (IAO:0000326)"
-                                    },
-                                    {
-                                        "cell_id": "2.22.2",
-                                        "cell_text": "additional information, appendix, supplemental information, supplementary material, supporting information"
-                                    },
-                                    {
-                                        "cell_id": "2.22.3",
-                                        "cell_text": "additional file, additional files, additional information and declarations, additional points, electronic supplementary material, electronic supplementary materials, online content, supplemental data, supplemental material, supplementary data, supplementary figures and tables, supplementary files, supplementary information, supplementary materials, supplementary materials figures, supplementary materials figures and tables, supplementary materials table, supplementary materials tables"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "offset": 4116,
-                    "infons": {
-                        "section_title_1": "table_footer",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "<sup>a</sup>IAO v2020-06-10.<sup>b</sup>Elements in italics have previously been submitted by us for inclusion into IAO and added in the v2020-12-09 IAO release."
-                }
-            ]
+          "offset": 1,
+          "infons": {
+            "section_title_1": "table_caption",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "Publishers and journals included in the publisher dataset."
         },
         {
-            "inputfile": "tests/data/PMC8885717.html",
-            "id": "3",
-            "infons": {},
-            "passages": [
-                {
-                    "offset": 0,
-                    "infons": {
-                        "section_title_1": "table_title",
-                        "iao_name_1": "document title",
-                        "iao_id_1": "IAO:0000305"
-                    },
-                    "text": [
-                        "Table 3"
-                    ]
-                },
-                {
-                    "offset": 1,
-                    "infons": {
-                        "section_title_1": "table_caption",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "(A) Proposed new IAO terms to define publication sections that were derived from analyzing the sections of 2,441 publications. (B) Proposed new IAO terms to define parts of a table section. Elements in italics have previously been submitted by us for inclusion into IAO and added in the v2020-12-09 IAO release."
-                },
-                {
-                    "offset": 312,
-                    "infons": {
-                        "section_title_1": "table_content",
-                        "iao_name_1": "table",
-                        "iao_id_1": "IAO:0000306"
-                    },
-                    "column_headings": [
-                        {
-                            "cell_id": "3.1.1",
-                            "cell_text": ""
-                        },
-                        {
-                            "cell_id": "3.1.2",
-                            "cell_text": "Proposed definition"
-                        },
-                        {
-                            "cell_id": "3.1.3",
-                            "cell_text": "Proposed synonyms"
-                        }
-                    ],
-                    "data_section": [
-                        {
-                            "table_section_title_1": "",
-                            "data_rows": [
-                                [
-                                    {
-                                        "cell_id": "3.2.1",
-                                        "cell_text": "(A) Proposed category"
-                                    },
-                                    {
-                                        "cell_id": "3.2.2",
-                                        "cell_text": "(A) Proposed category"
-                                    },
-                                    {
-                                        "cell_id": "3.2.3",
-                                        "cell_text": "(A) Proposed category"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.3.1",
-                                        "cell_text": "Disclosure"
-                                    },
-                                    {
-                                        "cell_id": "3.3.2",
-                                        "cell_text": "\u201cA part of a document used to disclose any associations by authors that might be perceived as to potentially interfere with or prevent them from reporting research with complete objectivity.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.3.3",
-                                        "cell_text": "Author disclosure statement, declarations, disclosure, disclosure statement, disclosures"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.4.1",
-                                        "cell_text": "Graphical abstract"
-                                    },
-                                    {
-                                        "cell_id": "3.4.2",
-                                        "cell_text": "\u201cAn abstract that is a pictorial summary of the main findings described in a document.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.4.3",
-                                        "cell_text": "Central illustration, graphical abstract, TOC image, visual abstract"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.5.1",
-                                        "cell_text": "Highlights"
-                                    },
-                                    {
-                                        "cell_id": "3.5.2",
-                                        "cell_text": "\u201cA short collection of key messages that describe the core findings and essence of the article in concise form. It is distinct and separate from the abstract and only conveys the results and concept of a study. It is devoid of jargon, acronyms and abbreviations and targeted at a broader, non-technical audience.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.5.3",
-                                        "cell_text": "Author summary, editors' summary, highlights, key points, overview, research in context, significance, TOC"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.6.1",
-                                        "cell_text": "Participants"
-                                    },
-                                    {
-                                        "cell_id": "3.6.2",
-                                        "cell_text": "\u201cA section describing the recruitment of subjects into a research study. This section is distinct from the \u2018patients' section and mostly focusses on healthy volunteers.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.6.3",
-                                        "cell_text": "Participants, sample"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.7.1",
-                                        "cell_text": "(B) Proposed category"
-                                    },
-                                    {
-                                        "cell_id": "3.7.2",
-                                        "cell_text": "(B) Proposed category"
-                                    },
-                                    {
-                                        "cell_id": "3.7.3",
-                                        "cell_text": "(B) Proposed category"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.8.1",
-                                        "cell_text": "Table title"
-                                    },
-                                    {
-                                        "cell_id": "3.8.2",
-                                        "cell_text": "\u201cA textual entity that names a table.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.8.3",
-                                        "cell_text": ""
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.9.1",
-                                        "cell_text": "Table caption"
-                                    },
-                                    {
-                                        "cell_id": "3.9.2",
-                                        "cell_text": "\u201cA textual entity that describes a table.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.9.3",
-                                        "cell_text": ""
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "3.10.1",
-                                        "cell_text": "Table footer"
-                                    },
-                                    {
-                                        "cell_id": "3.10.2",
-                                        "cell_text": "\u201cA part of a table that provides additional information about a specific other part of the table. Footers are spatially segregated from the rest of the table and are usually indicated by a superscripted number or letter, or a special typographic character such as \u2020.\u201d"
-                                    },
-                                    {
-                                        "cell_id": "3.10.3",
-                                        "cell_text": "Table key, table note, table notes"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                }
-            ]
+          "offset": 59,
+          "infons": {
+            "section_title_1": "table_content",
+            "iao_name_1": "table",
+            "iao_id_1": "IAO:0000306"
+          },
+          "column_headings": [
+            {
+              "cell_id": "1.1.1",
+              "cell_text": "Publisher"
+            },
+            {
+              "cell_id": "1.1.2",
+              "cell_text": "Journal"
+            },
+            {
+              "cell_id": "1.1.3",
+              "cell_text": "Number of full-text files"
+            },
+            {
+              "cell_id": "1.1.4",
+              "cell_text": "Overlap with OA dataset"
+            },
+            {
+              "cell_id": "1.1.5",
+              "cell_text": "Table type"
+            },
+            {
+              "cell_id": "1.1.6",
+              "cell_text": "Number of table files"
+            }
+          ],
+          "data_section": [
+            {
+              "table_section_title_1": "",
+              "data_rows": [
+                [
+                  {
+                    "cell_id": "1.2.1",
+                    "cell_text": "American Heart Association"
+                  },
+                  {
+                    "cell_id": "1.2.2",
+                    "cell_text": "Circulation Cardiovascular Genetics"
+                  },
+                  {
+                    "cell_id": "1.2.3",
+                    "cell_text": 52.0
+                  },
+                  {
+                    "cell_id": "1.2.4",
+                    "cell_text": 39.0
+                  },
+                  {
+                    "cell_id": "1.2.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.2.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.3.1",
+                    "cell_text": "American Physical Society"
+                  },
+                  {
+                    "cell_id": "1.3.2",
+                    "cell_text": "Physical Review Letters<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.3.3",
+                    "cell_text": 6.0
+                  },
+                  {
+                    "cell_id": "1.3.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.3.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.3.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.4.1",
+                    "cell_text": "American Psychological Association"
+                  },
+                  {
+                    "cell_id": "1.4.2",
+                    "cell_text": "Psychological Bulletin<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.4.3",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.4.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.4.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.4.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.5.1",
+                    "cell_text": "American Society of Hematology"
+                  },
+                  {
+                    "cell_id": "1.5.2",
+                    "cell_text": "Blood"
+                  },
+                  {
+                    "cell_id": "1.5.3",
+                    "cell_text": 31.0
+                  },
+                  {
+                    "cell_id": "1.5.4",
+                    "cell_text": 25.0
+                  },
+                  {
+                    "cell_id": "1.5.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.5.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.6.1",
+                    "cell_text": "American Thoracic Society"
+                  },
+                  {
+                    "cell_id": "1.6.2",
+                    "cell_text": "American Journal of Respiratory and Critical Care Medicine"
+                  },
+                  {
+                    "cell_id": "1.6.3",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.6.4",
+                    "cell_text": 18.0
+                  },
+                  {
+                    "cell_id": "1.6.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.6.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.7.1",
+                    "cell_text": "BioMed Central"
+                  },
+                  {
+                    "cell_id": "1.7.2",
+                    "cell_text": "BMC Medical Genetics"
+                  },
+                  {
+                    "cell_id": "1.7.3",
+                    "cell_text": 43.0
+                  },
+                  {
+                    "cell_id": "1.7.4",
+                    "cell_text": 43.0
+                  },
+                  {
+                    "cell_id": "1.7.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.7.6",
+                    "cell_text": 160.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.8.1",
+                    "cell_text": "Cell Press"
+                  },
+                  {
+                    "cell_id": "1.8.2",
+                    "cell_text": "American Journal of Human Genetics"
+                  },
+                  {
+                    "cell_id": "1.8.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.8.4",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.8.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.8.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.9.1",
+                    "cell_text": "Elsevier"
+                  },
+                  {
+                    "cell_id": "1.9.2",
+                    "cell_text": "Biological Psychiatry"
+                  },
+                  {
+                    "cell_id": "1.9.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.9.4",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.9.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.9.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.10.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.10.2",
+                    "cell_text": "Gastroenterology"
+                  },
+                  {
+                    "cell_id": "1.10.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.10.4",
+                    "cell_text": 2.0
+                  },
+                  {
+                    "cell_id": "1.10.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.10.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.11.1",
+                    "cell_text": "Frontiers"
+                  },
+                  {
+                    "cell_id": "1.11.2",
+                    "cell_text": "Frontiers in Genetics"
+                  },
+                  {
+                    "cell_id": "1.11.3",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.11.4",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.11.5",
+                    "cell_text": "Linked images"
+                  },
+                  {
+                    "cell_id": "1.11.6",
+                    "cell_text": "n/a"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.12.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.12.2",
+                    "cell_text": "Frontiers in Physics<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.12.3",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.12.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.12.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.12.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.13.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.13.2",
+                    "cell_text": "Frontiers in Psychology<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.13.3",
+                    "cell_text": 4.0
+                  },
+                  {
+                    "cell_id": "1.13.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.13.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.13.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.14.1",
+                    "cell_text": "Massachusetts Medical Society"
+                  },
+                  {
+                    "cell_id": "1.14.2",
+                    "cell_text": "The New England Journal of Medicine"
+                  },
+                  {
+                    "cell_id": "1.14.3",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.14.4",
+                    "cell_text": 12.0
+                  },
+                  {
+                    "cell_id": "1.14.5",
+                    "cell_text": "Linked images"
+                  },
+                  {
+                    "cell_id": "1.14.6",
+                    "cell_text": "n/a"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.15.1",
+                    "cell_text": "Mosby"
+                  },
+                  {
+                    "cell_id": "1.15.2",
+                    "cell_text": "The Journal of Allergy and Clinical Immunology"
+                  },
+                  {
+                    "cell_id": "1.15.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.15.4",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.15.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.15.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.16.1",
+                    "cell_text": "Nature Portfolio"
+                  },
+                  {
+                    "cell_id": "1.16.2",
+                    "cell_text": "European Journal of Human Genetics"
+                  },
+                  {
+                    "cell_id": "1.16.3",
+                    "cell_text": 50.0
+                  },
+                  {
+                    "cell_id": "1.16.4",
+                    "cell_text": 50.0
+                  },
+                  {
+                    "cell_id": "1.16.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.16.6",
+                    "cell_text": 123.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.17.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.17.2",
+                    "cell_text": "Journal of Human Genetics"
+                  },
+                  {
+                    "cell_id": "1.17.3",
+                    "cell_text": 37.0
+                  },
+                  {
+                    "cell_id": "1.17.4",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.17.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.17.6",
+                    "cell_text": 90.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.18.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.18.2",
+                    "cell_text": "Molecular Psychiatry"
+                  },
+                  {
+                    "cell_id": "1.18.3",
+                    "cell_text": 103.0
+                  },
+                  {
+                    "cell_id": "1.18.4",
+                    "cell_text": 78.0
+                  },
+                  {
+                    "cell_id": "1.18.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.18.6",
+                    "cell_text": 262.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.19.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.19.2",
+                    "cell_text": "Nature Physics<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.19.3",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.19.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.19.5",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.19.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.20.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.20.2",
+                    "cell_text": "Scientific Reports"
+                  },
+                  {
+                    "cell_id": "1.20.3",
+                    "cell_text": 80.0
+                  },
+                  {
+                    "cell_id": "1.20.4",
+                    "cell_text": 80.0
+                  },
+                  {
+                    "cell_id": "1.20.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.20.6",
+                    "cell_text": 190.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.21.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.21.2",
+                    "cell_text": "The Pharmacogenomics Journal"
+                  },
+                  {
+                    "cell_id": "1.21.3",
+                    "cell_text": 37.0
+                  },
+                  {
+                    "cell_id": "1.21.4",
+                    "cell_text": 16.0
+                  },
+                  {
+                    "cell_id": "1.21.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.21.6",
+                    "cell_text": 116.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.22.1",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.22.2",
+                    "cell_text": "Translational Psychiatry"
+                  },
+                  {
+                    "cell_id": "1.22.3",
+                    "cell_text": 41.0
+                  },
+                  {
+                    "cell_id": "1.22.4",
+                    "cell_text": 41.0
+                  },
+                  {
+                    "cell_id": "1.22.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.22.6",
+                    "cell_text": 87.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.23.1",
+                    "cell_text": "Oxford University Press"
+                  },
+                  {
+                    "cell_id": "1.23.2",
+                    "cell_text": "Human Molecular Genetics"
+                  },
+                  {
+                    "cell_id": "1.23.3",
+                    "cell_text": 254.0
+                  },
+                  {
+                    "cell_id": "1.23.4",
+                    "cell_text": 186.0
+                  },
+                  {
+                    "cell_id": "1.23.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.23.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.24.1",
+                    "cell_text": "PLOS"
+                  },
+                  {
+                    "cell_id": "1.24.2",
+                    "cell_text": "PLOS One"
+                  },
+                  {
+                    "cell_id": "1.24.3",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.24.4",
+                    "cell_text": 20.0
+                  },
+                  {
+                    "cell_id": "1.24.5",
+                    "cell_text": "Linked images"
+                  },
+                  {
+                    "cell_id": "1.24.6",
+                    "cell_text": "n/a"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.25.1",
+                    "cell_text": "SAGE Publications"
+                  },
+                  {
+                    "cell_id": "1.25.2",
+                    "cell_text": "Psychological Science<sup>a</sup>"
+                  },
+                  {
+                    "cell_id": "1.25.3",
+                    "cell_text": 3.0
+                  },
+                  {
+                    "cell_id": "1.25.4",
+                    "cell_text": "–"
+                  },
+                  {
+                    "cell_id": "1.25.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.25.6",
+                    "cell_text": "-"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.26.1",
+                    "cell_text": "Springer"
+                  },
+                  {
+                    "cell_id": "1.26.2",
+                    "cell_text": "Human Genetics"
+                  },
+                  {
+                    "cell_id": "1.26.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.26.4",
+                    "cell_text": 2.0
+                  },
+                  {
+                    "cell_id": "1.26.5",
+                    "cell_text": "Linked HTML"
+                  },
+                  {
+                    "cell_id": "1.26.6",
+                    "cell_text": 13.0
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.27.1",
+                    "cell_text": "Wiley-Blackwell"
+                  },
+                  {
+                    "cell_id": "1.27.2",
+                    "cell_text": "American Journal of Medical Genetics"
+                  },
+                  {
+                    "cell_id": "1.27.3",
+                    "cell_text": 5.0
+                  },
+                  {
+                    "cell_id": "1.27.4",
+                    "cell_text": 0.0
+                  },
+                  {
+                    "cell_id": "1.27.5",
+                    "cell_text": "Inline"
+                  },
+                  {
+                    "cell_id": "1.27.6",
+                    "cell_text": "–"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "1.28.1",
+                    "cell_text": "Total"
+                  },
+                  {
+                    "cell_id": "1.28.2",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.28.3",
+                    "cell_text": 860.0
+                  },
+                  {
+                    "cell_id": "1.28.4",
+                    "cell_text": 648.0
+                  },
+                  {
+                    "cell_id": "1.28.5",
+                    "cell_text": ""
+                  },
+                  {
+                    "cell_id": "1.28.6",
+                    "cell_text": 1041.0
+                  }
+                ]
+              ]
+            }
+          ]
         },
         {
-            "inputfile": "tests/data/PMC8885717.html",
-            "id": "4",
-            "infons": {},
-            "passages": [
-                {
-                    "offset": 0,
-                    "infons": {
-                        "section_title_1": "table_title",
-                        "iao_name_1": "document title",
-                        "iao_id_1": "IAO:0000305"
-                    },
-                    "text": [
-                        "Table 4"
-                    ]
-                },
-                {
-                    "offset": 1,
-                    "infons": {
-                        "section_title_1": "table_caption",
-                        "iao_name_1": "caption",
-                        "iao_id_1": "IAO:0000304"
-                    },
-                    "text": "Differences between the Auto-CORPus BioC and PMC BioC JSON outputs."
-                },
-                {
-                    "offset": 68,
-                    "infons": {
-                        "section_title_1": "table_content",
-                        "iao_name_1": "table",
-                        "iao_id_1": "IAO:0000306"
-                    },
-                    "column_headings": [
-                        {
-                            "cell_id": "4.1.1",
-                            "cell_text": "Difference"
-                        },
-                        {
-                            "cell_id": "4.1.2",
-                            "cell_text": "Auto-CORPus"
-                        },
-                        {
-                            "cell_id": "4.1.3",
-                            "cell_text": "PMC"
-                        }
-                    ],
-                    "data_section": [
-                        {
-                            "table_section_title_1": "",
-                            "data_rows": [
-                                [
-                                    {
-                                        "cell_id": "4.2.1",
-                                        "cell_text": "Section titles"
-                                    },
-                                    {
-                                        "cell_id": "4.2.2",
-                                        "cell_text": "Section titles, subtitles, subsubtitles (and so on) are linked to the passage text they apply to"
-                                    },
-                                    {
-                                        "cell_id": "4.2.3",
-                                        "cell_text": "Section titles, subtitles, subsubtitles (and so on) precede the passage text they apply to"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.3.1",
-                                        "cell_text": "Section types"
-                                    },
-                                    {
-                                        "cell_id": "4.3.2",
-                                        "cell_text": "Section types are annotated using IAO terms"
-                                    },
-                                    {
-                                        "cell_id": "4.3.3",
-                                        "cell_text": "Section types are described using custom labels"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.4.1",
-                                        "cell_text": "Offset counts"
-                                    },
-                                    {
-                                        "cell_id": "4.4.2",
-                                        "cell_text": "Offset increased by 1 for every character (including whitespace) in a passage"
-                                    },
-                                    {
-                                        "cell_id": "4.4.3",
-                                        "cell_text": "Offset increased by the number of bytes in the text of a passage plus one space"
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.5.1",
-                                        "cell_text": "Table and figure sections"
-                                    },
-                                    {
-                                        "cell_id": "4.5.2",
-                                        "cell_text": "Structured table data are stored in table JSON. Figure captions are included in the BioC JSON in the sequential order in which they occur within paragraphs."
-                                    },
-                                    {
-                                        "cell_id": "4.5.3",
-                                        "cell_text": "Table data and figure captions occur at the end of the JSON document. Table content is given as XML."
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.6.1",
-                                        "cell_text": "Abbreviations section"
-                                    },
-                                    {
-                                        "cell_id": "4.6.2",
-                                        "cell_text": "Abbreviations section stored in abbreviations JSON. Abbreviation and definition components are related. Incomplete/one-sided definitions are not stored."
-                                    },
-                                    {
-                                        "cell_id": "4.6.3",
-                                        "cell_text": "Abbreviations and definitions from the abbreviations section are stored separately as text with no relations between the two components. Incomplete/one-sided definitions are stored."
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.7.1",
-                                        "cell_text": "Link anchor text"
-                                    },
-                                    {
-                                        "cell_id": "4.7.2",
-                                        "cell_text": "Link anchor text retained (HTML element tags removed)."
-                                    },
-                                    {
-                                        "cell_id": "4.7.3",
-                                        "cell_text": "Link anchor text removed."
-                                    }
-                                ],
-                                [
-                                    {
-                                        "cell_id": "4.8.1",
-                                        "cell_text": "Character encoding"
-                                    },
-                                    {
-                                        "cell_id": "4.8.2",
-                                        "cell_text": "UTF-8 used for outputs"
-                                    },
-                                    {
-                                        "cell_id": "4.8.3",
-                                        "cell_text": "Available in Unicode and ASCII"
-                                    }
-                                ]
-                            ]
-                        }
-                    ]
-                }
-            ]
+          "offset": 1542,
+          "infons": {
+            "section_title_1": "table_footer",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "The full-text files were downloaded in HTML format and the linked table files were downloaded when available in HTML formats. The full-text files that overlap with the OA dataset were used to assess the consistency of outputs generated from different sources.<sup>a</sup>These publications are not part of the publisher dataset for evaluating tables, but are used for evaluating the accuracy of IAO header mapping."
         }
-    ]
+      ]
+    },
+    {
+      "inputfile": "tests/data/PMC8885717.html",
+      "id": "2",
+      "infons": {},
+      "passages": [
+        {
+          "offset": 0,
+          "infons": {
+            "section_title_1": "table_title",
+            "iao_name_1": "document title",
+            "iao_id_1": "IAO:0000305"
+          },
+          "text": [
+            "Table 2"
+          ]
+        },
+        {
+          "offset": 1,
+          "infons": {
+            "section_title_1": "table_caption",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "New synonyms identified for existing IAO terms from the fuzzy and digraph mappings of 2,441 publications."
+        },
+        {
+          "offset": 106,
+          "infons": {
+            "section_title_1": "table_content",
+            "iao_name_1": "table",
+            "iao_id_1": "IAO:0000306"
+          },
+          "column_headings": [
+            {
+              "cell_id": "2.1.1",
+              "cell_text": "Category (IAO identifier)"
+            },
+            {
+              "cell_id": "2.1.2",
+              "cell_text": "Existing synonyms<sup>a</sup>"
+            },
+            {
+              "cell_id": "2.1.3",
+              "cell_text": "New synonyms identified<sup>b</sup>"
+            }
+          ],
+          "data_section": [
+            {
+              "table_section_title_1": "",
+              "data_rows": [
+                [
+                  {
+                    "cell_id": "2.2.1",
+                    "cell_text": "abbreviations (IAO:0000606)"
+                  },
+                  {
+                    "cell_id": "2.2.2",
+                    "cell_text": "abbreviations, abbreviations list, abbreviations used, list of abbreviations, list of abbreviations used"
+                  },
+                  {
+                    "cell_id": "2.2.3",
+                    "cell_text": "abbreviation and acronyms, abbreviation list, abbreviations and acronyms, abbreviations used in this paper, definitions for abbreviations, glossary, key abbreviations, non-standard abbreviations, nonstandard abbreviations, nonstandard abbreviations and acronyms"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.3.1",
+                    "cell_text": "abstract (IAO:0000315)"
+                  },
+                  {
+                    "cell_id": "2.3.2",
+                    "cell_text": "abstract"
+                  },
+                  {
+                    "cell_id": "2.3.3",
+                    "cell_text": "precis"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.4.1",
+                    "cell_text": "acknowledgments (IAO:0000324)"
+                  },
+                  {
+                    "cell_id": "2.4.2",
+                    "cell_text": "acknowledgments, acknowledgments"
+                  },
+                  {
+                    "cell_id": "2.4.3",
+                    "cell_text": "acknowledgment, acknowledgment, acknowledgments and disclaimer"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.5.1",
+                    "cell_text": "author contributions (IAO:0000323)"
+                  },
+                  {
+                    "cell_id": "2.5.2",
+                    "cell_text": "author contributions, contributions by the authors"
+                  },
+                  {
+                    "cell_id": "2.5.3",
+                    "cell_text": "authors' contribution, authors' contributions, authors' roles, contributorship, main authors by consortium and author contributions"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.6.1",
+                    "cell_text": "author information (IAO:0000607)"
+                  },
+                  {
+                    "cell_id": "2.6.2",
+                    "cell_text": "author information, authors' information"
+                  },
+                  {
+                    "cell_id": "2.6.3",
+                    "cell_text": "biographies, contributor information"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.7.1",
+                    "cell_text": "availability (IAO:0000611)"
+                  },
+                  {
+                    "cell_id": "2.7.2",
+                    "cell_text": "availability, availability and requirements"
+                  },
+                  {
+                    "cell_id": "2.7.3",
+                    "cell_text": "availability of data, availability of data and materials, data archiving, data availability, data availability statement, data sharing statement"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.8.1",
+                    "cell_text": "conclusion (IAO:0000615)"
+                  },
+                  {
+                    "cell_id": "2.8.2",
+                    "cell_text": "concluding remarks, conclusion, conclusions, findings, summary"
+                  },
+                  {
+                    "cell_id": "2.8.3",
+                    "cell_text": "conclusion and perspectives, summary and conclusion"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.9.1",
+                    "cell_text": "conflict of interest (IAO:0000616)"
+                  },
+                  {
+                    "cell_id": "2.9.2",
+                    "cell_text": "competing interests, conflict of interest, conflict of interest statement, declaration of competing interests, disclosure of potential conflicts of interest"
+                  },
+                  {
+                    "cell_id": "2.9.3",
+                    "cell_text": "authors' disclosures of potential conflicts of interest, competing financial interests, conflict of interests, conflicts of interest, declaration of competing interest, declaration of interest, declaration of interests, disclosure of conflict of interest, duality of interest, statement of interest"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.10.1",
+                    "cell_text": "consent (IAO:0000618)"
+                  },
+                  {
+                    "cell_id": "2.10.2",
+                    "cell_text": "consent"
+                  },
+                  {
+                    "cell_id": "2.10.3",
+                    "cell_text": "Informed consent"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.11.1",
+                    "cell_text": "discussion (IAO:0000319)"
+                  },
+                  {
+                    "cell_id": "2.11.2",
+                    "cell_text": "discussion, discussion section"
+                  },
+                  {
+                    "cell_id": "2.11.3",
+                    "cell_text": "discussions"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.12.1",
+                    "cell_text": "ethical approval (IAO:0000620)"
+                  },
+                  {
+                    "cell_id": "2.12.2",
+                    "cell_text": "ethical approval"
+                  },
+                  {
+                    "cell_id": "2.12.3",
+                    "cell_text": "ethics approval and consent to participate, ethical requirements, ethics, ethics statement"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.13.1",
+                    "cell_text": "footnote (IAO:0000325)"
+                  },
+                  {
+                    "cell_id": "2.13.2",
+                    "cell_text": "endnote, footnote"
+                  },
+                  {
+                    "cell_id": "2.13.3",
+                    "cell_text": "footnotes"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.14.1",
+                    "cell_text": "funding source declaration (IAO:0000623)"
+                  },
+                  {
+                    "cell_id": "2.14.2",
+                    "cell_text": "funding, funding information, funding sources, funding statement, funding/support, source of funding, sources of funding"
+                  },
+                  {
+                    "cell_id": "2.14.3",
+                    "cell_text": "financial support, grants, role of the funding source, study funding"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.15.1",
+                    "cell_text": "future directions (IAO:0000625)"
+                  },
+                  {
+                    "cell_id": "2.15.2",
+                    "cell_text": "future challenges, future considerations, future developments, future directions, future outlook, future perspectives, future plans, future prospects, future research, future research directions, future studies, future work"
+                  },
+                  {
+                    "cell_id": "2.15.3",
+                    "cell_text": "outlook"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.16.1",
+                    "cell_text": "introduction (IAO:0000316)"
+                  },
+                  {
+                    "cell_id": "2.16.2",
+                    "cell_text": "background, introduction"
+                  },
+                  {
+                    "cell_id": "2.16.3",
+                    "cell_text": "introductory paragraph"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.17.1",
+                    "cell_text": "materials (IAO:0000633)"
+                  },
+                  {
+                    "cell_id": "2.17.2",
+                    "cell_text": "materials"
+                  },
+                  {
+                    "cell_id": "2.17.3",
+                    "cell_text": "data, data description"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.18.1",
+                    "cell_text": "methods (IAO:0000317)"
+                  },
+                  {
+                    "cell_id": "2.18.2",
+                    "cell_text": "experimental, experimental procedures, experimental section, materials and methods, methods"
+                  },
+                  {
+                    "cell_id": "2.18.3",
+                    "cell_text": "analytical methods, concise methods, experimental methods, method, method validation, methodology, methods and design, methods and procedures, methods and tools, methods/design, online methods, star methods, study design, study design and methods"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.19.1",
+                    "cell_text": "references (IAO:0000320)"
+                  },
+                  {
+                    "cell_id": "2.19.2",
+                    "cell_text": "bibliography, literature cited, references"
+                  },
+                  {
+                    "cell_id": "2.19.3",
+                    "cell_text": "literature cited, reference, references, reference list, selected references, web site references"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.20.1",
+                    "cell_text": "statistical analysis (IAO:0000644)"
+                  },
+                  {
+                    "cell_id": "2.20.2",
+                    "cell_text": "statistical analysis"
+                  },
+                  {
+                    "cell_id": "2.20.3",
+                    "cell_text": "statistical methods, statistical methods and analysis, statistics"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.21.1",
+                    "cell_text": "study limitations (IAO:0000631)"
+                  },
+                  {
+                    "cell_id": "2.21.2",
+                    "cell_text": "limitations, study limitations"
+                  },
+                  {
+                    "cell_id": "2.21.3",
+                    "cell_text": "strengths and limitations, study strengths and limitations"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "2.22.1",
+                    "cell_text": "supplementary material (IAO:0000326)"
+                  },
+                  {
+                    "cell_id": "2.22.2",
+                    "cell_text": "additional information, appendix, supplemental information, supplementary material, supporting information"
+                  },
+                  {
+                    "cell_id": "2.22.3",
+                    "cell_text": "additional file, additional files, additional information and declarations, additional points, electronic supplementary material, electronic supplementary materials, online content, supplemental data, supplemental material, supplementary data, supplementary figures and tables, supplementary files, supplementary information, supplementary materials, supplementary materials figures, supplementary materials figures and tables, supplementary materials table, supplementary materials tables"
+                  }
+                ]
+              ]
+            }
+          ]
+        },
+        {
+          "offset": 4116,
+          "infons": {
+            "section_title_1": "table_footer",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "<sup>a</sup>IAO v2020-06-10.<sup>b</sup>Elements in italics have previously been submitted by us for inclusion into IAO and added in the v2020-12-09 IAO release."
+        }
+      ]
+    },
+    {
+      "inputfile": "tests/data/PMC8885717.html",
+      "id": "3",
+      "infons": {},
+      "passages": [
+        {
+          "offset": 0,
+          "infons": {
+            "section_title_1": "table_title",
+            "iao_name_1": "document title",
+            "iao_id_1": "IAO:0000305"
+          },
+          "text": [
+            "Table 3"
+          ]
+        },
+        {
+          "offset": 1,
+          "infons": {
+            "section_title_1": "table_caption",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "(A) Proposed new IAO terms to define publication sections that were derived from analyzing the sections of 2,441 publications. (B) Proposed new IAO terms to define parts of a table section. Elements in italics have previously been submitted by us for inclusion into IAO and added in the v2020-12-09 IAO release."
+        },
+        {
+          "offset": 312,
+          "infons": {
+            "section_title_1": "table_content",
+            "iao_name_1": "table",
+            "iao_id_1": "IAO:0000306"
+          },
+          "column_headings": [
+            {
+              "cell_id": "3.1.1",
+              "cell_text": ""
+            },
+            {
+              "cell_id": "3.1.2",
+              "cell_text": "Proposed definition"
+            },
+            {
+              "cell_id": "3.1.3",
+              "cell_text": "Proposed synonyms"
+            }
+          ],
+          "data_section": [
+            {
+              "table_section_title_1": "",
+              "data_rows": [
+                [
+                  {
+                    "cell_id": "3.2.1",
+                    "cell_text": "(A) Proposed category"
+                  },
+                  {
+                    "cell_id": "3.2.2",
+                    "cell_text": "(A) Proposed category"
+                  },
+                  {
+                    "cell_id": "3.2.3",
+                    "cell_text": "(A) Proposed category"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.3.1",
+                    "cell_text": "Disclosure"
+                  },
+                  {
+                    "cell_id": "3.3.2",
+                    "cell_text": "“A part of a document used to disclose any associations by authors that might be perceived as to potentially interfere with or prevent them from reporting research with complete objectivity.”"
+                  },
+                  {
+                    "cell_id": "3.3.3",
+                    "cell_text": "Author disclosure statement, declarations, disclosure, disclosure statement, disclosures"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.4.1",
+                    "cell_text": "Graphical abstract"
+                  },
+                  {
+                    "cell_id": "3.4.2",
+                    "cell_text": "“An abstract that is a pictorial summary of the main findings described in a document.”"
+                  },
+                  {
+                    "cell_id": "3.4.3",
+                    "cell_text": "Central illustration, graphical abstract, TOC image, visual abstract"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.5.1",
+                    "cell_text": "Highlights"
+                  },
+                  {
+                    "cell_id": "3.5.2",
+                    "cell_text": "“A short collection of key messages that describe the core findings and essence of the article in concise form. It is distinct and separate from the abstract and only conveys the results and concept of a study. It is devoid of jargon, acronyms and abbreviations and targeted at a broader, non-technical audience.”"
+                  },
+                  {
+                    "cell_id": "3.5.3",
+                    "cell_text": "Author summary, editors' summary, highlights, key points, overview, research in context, significance, TOC"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.6.1",
+                    "cell_text": "Participants"
+                  },
+                  {
+                    "cell_id": "3.6.2",
+                    "cell_text": "“A section describing the recruitment of subjects into a research study. This section is distinct from the ‘patients' section and mostly focusses on healthy volunteers.”"
+                  },
+                  {
+                    "cell_id": "3.6.3",
+                    "cell_text": "Participants, sample"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.7.1",
+                    "cell_text": "(B) Proposed category"
+                  },
+                  {
+                    "cell_id": "3.7.2",
+                    "cell_text": "(B) Proposed category"
+                  },
+                  {
+                    "cell_id": "3.7.3",
+                    "cell_text": "(B) Proposed category"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.8.1",
+                    "cell_text": "Table title"
+                  },
+                  {
+                    "cell_id": "3.8.2",
+                    "cell_text": "“A textual entity that names a table.”"
+                  },
+                  {
+                    "cell_id": "3.8.3",
+                    "cell_text": ""
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.9.1",
+                    "cell_text": "Table caption"
+                  },
+                  {
+                    "cell_id": "3.9.2",
+                    "cell_text": "“A textual entity that describes a table.”"
+                  },
+                  {
+                    "cell_id": "3.9.3",
+                    "cell_text": ""
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "3.10.1",
+                    "cell_text": "Table footer"
+                  },
+                  {
+                    "cell_id": "3.10.2",
+                    "cell_text": "“A part of a table that provides additional information about a specific other part of the table. Footers are spatially segregated from the rest of the table and are usually indicated by a superscripted number or letter, or a special typographic character such as †.”"
+                  },
+                  {
+                    "cell_id": "3.10.3",
+                    "cell_text": "Table key, table note, table notes"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "inputfile": "tests/data/PMC8885717.html",
+      "id": "4",
+      "infons": {},
+      "passages": [
+        {
+          "offset": 0,
+          "infons": {
+            "section_title_1": "table_title",
+            "iao_name_1": "document title",
+            "iao_id_1": "IAO:0000305"
+          },
+          "text": [
+            "Table 4"
+          ]
+        },
+        {
+          "offset": 1,
+          "infons": {
+            "section_title_1": "table_caption",
+            "iao_name_1": "caption",
+            "iao_id_1": "IAO:0000304"
+          },
+          "text": "Differences between the Auto-CORPus BioC and PMC BioC JSON outputs."
+        },
+        {
+          "offset": 68,
+          "infons": {
+            "section_title_1": "table_content",
+            "iao_name_1": "table",
+            "iao_id_1": "IAO:0000306"
+          },
+          "column_headings": [
+            {
+              "cell_id": "4.1.1",
+              "cell_text": "Difference"
+            },
+            {
+              "cell_id": "4.1.2",
+              "cell_text": "Auto-CORPus"
+            },
+            {
+              "cell_id": "4.1.3",
+              "cell_text": "PMC"
+            }
+          ],
+          "data_section": [
+            {
+              "table_section_title_1": "",
+              "data_rows": [
+                [
+                  {
+                    "cell_id": "4.2.1",
+                    "cell_text": "Section titles"
+                  },
+                  {
+                    "cell_id": "4.2.2",
+                    "cell_text": "Section titles, subtitles, subsubtitles (and so on) are linked to the passage text they apply to"
+                  },
+                  {
+                    "cell_id": "4.2.3",
+                    "cell_text": "Section titles, subtitles, subsubtitles (and so on) precede the passage text they apply to"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.3.1",
+                    "cell_text": "Section types"
+                  },
+                  {
+                    "cell_id": "4.3.2",
+                    "cell_text": "Section types are annotated using IAO terms"
+                  },
+                  {
+                    "cell_id": "4.3.3",
+                    "cell_text": "Section types are described using custom labels"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.4.1",
+                    "cell_text": "Offset counts"
+                  },
+                  {
+                    "cell_id": "4.4.2",
+                    "cell_text": "Offset increased by 1 for every character (including whitespace) in a passage"
+                  },
+                  {
+                    "cell_id": "4.4.3",
+                    "cell_text": "Offset increased by the number of bytes in the text of a passage plus one space"
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.5.1",
+                    "cell_text": "Table and figure sections"
+                  },
+                  {
+                    "cell_id": "4.5.2",
+                    "cell_text": "Structured table data are stored in table JSON. Figure captions are included in the BioC JSON in the sequential order in which they occur within paragraphs."
+                  },
+                  {
+                    "cell_id": "4.5.3",
+                    "cell_text": "Table data and figure captions occur at the end of the JSON document. Table content is given as XML."
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.6.1",
+                    "cell_text": "Abbreviations section"
+                  },
+                  {
+                    "cell_id": "4.6.2",
+                    "cell_text": "Abbreviations section stored in abbreviations JSON. Abbreviation and definition components are related. Incomplete/one-sided definitions are not stored."
+                  },
+                  {
+                    "cell_id": "4.6.3",
+                    "cell_text": "Abbreviations and definitions from the abbreviations section are stored separately as text with no relations between the two components. Incomplete/one-sided definitions are stored."
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.7.1",
+                    "cell_text": "Link anchor text"
+                  },
+                  {
+                    "cell_id": "4.7.2",
+                    "cell_text": "Link anchor text retained (HTML element tags removed)."
+                  },
+                  {
+                    "cell_id": "4.7.3",
+                    "cell_text": "Link anchor text removed."
+                  }
+                ],
+                [
+                  {
+                    "cell_id": "4.8.1",
+                    "cell_text": "Character encoding"
+                  },
+                  {
+                    "cell_id": "4.8.2",
+                    "cell_text": "UTF-8 used for outputs"
+                  },
+                  {
+                    "cell_id": "4.8.3",
+                    "cell_text": "Available in Unicode and ASCII"
+                  }
+                ]
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
This is a follow-up to @tsmbland's PR.

We've reverted all the changes that were made to the files in `tests/data` (we want these to be the same as they would be if you got them from the web) and have excluded the folder from all pre-commit hooks.

I've also split out the markdownlint configuration into a separate file and fixed a spelling mistake.