### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -324,6 +324,17 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+description = "Infer file type and MIME type of any file/buffer. No external dependencies."
+optional = false
+python-versions = "*"
+files = [
+    {file = "filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25"},
+    {file = "filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb"},
+]
+
+[[package]]
 name = "fuzzywuzzy"
 version = "0.18.0"
 description = "Fuzzy string matching in python"
@@ -1864,4 +1875,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "b4897c669180efd065d94b6fef3147da57e4488fe0589167bfef1d2a62991812"
+content-hash = "99b83470b900361554987d2d0525a2edf9136776087cf95b5f28dc69b80650dc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1874,5 +1874,5 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.10,<3.13"
-content-hash = "99b83470b900361554987d2d0525a2edf9136776087cf95b5f28dc69b80650dc"
+python-versions = ">=3.10,<4"
+content-hash = "75a6f4e5f015ffee1d3c95d00faa47d8c0de91dcd68e5502f33919bf7978fcaf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0-only"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.10,<4"
 regex = "^2024.9.11"
 bioc = "^2.1"
 beautifulsoup4 = "^4.12.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ lxml = "^5.3.0"
 networkx = "^3.4.2"
 opencv-contrib-python = "^4.10.0.84"
 python-levenshtein = "^0.26.1"
+filetype = "^1.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/run_app.py
+++ b/run_app.py
@@ -1,9 +1,9 @@
 import argparse
-import imghdr
 import re
 from datetime import datetime
 from pathlib import Path
 
+from filetype import is_image
 from tqdm import tqdm
 
 from src.autoCORPus import autoCORPus
@@ -62,9 +62,9 @@ def get_file_type(file_path):
             return "linked_tables"
         else:
             return "main_text"
-    elif imghdr.what(file_path):
-        # imghdr returns the type of image a file is (png/jpeg etc or None if not an image)
-        # this should be tidied up to only include the image types which are supported by AC instead of any image files
+    elif is_image(file_path):
+        # this should be tidied up to only include the image types which are supported
+        # by AC instead of any image files
         return "table_images"
     else:
         print(


### PR DESCRIPTION
This PR replaces the single use of the `imghdr` built-in package, which is no longer available in Python 3.13. This was the only barrier to using Python 3.13, so I've now updated the `pyproject.toml` and added it to the CI test matrix.

Closes #55.