### PR TITLE
Add workflow to publish on PyPI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,22 @@
+name: Set up
+description: Set up Python environment and install dependencies
+inputs:
+  python-version:
+    description: The Python version to use
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install Poetry
+      shell: bash
+      run: pipx install poetry
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: poetry
+
+    - name: Install dependencies
+      shell: bash
+      run: poetry install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,8 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v4
-      - name: Install poetry
-        run: pipx install poetry
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup
         with:
           python-version: ${{ matrix.python-version }}
-          cache: poetry
-      - name: Install dependencies
-        run: poetry install
       - name: Run tests
         run: poetry run pytest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
           # NB: tag name must be prefixed by "v" (the default for GitHub Releases)
           test v$pkgver = ${{ github.ref_name }}
 
-
       - name: Build package
         run: poetry build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,14 @@ jobs:
         with:
           python-version: '3.13'
 
+      - name: Check package version matches tag
+        run: |
+          pkgver=$(python -c "import autocorpus; print(autocorpus.__version__, end='')")
+
+          # NB: tag name must be prefixed by "v" (the default for GitHub Releases)
+          test v$pkgver = ${{ github.ref_name }}
+
+
       - name: Build package
         run: poetry build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    uses: ./.github/workflows/ci.yml
+
+  # If tests are successful, we build the wheel and push it to the release
+  build-wheel:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          python-version: '3.13'
+
+      - name: Build package
+        run: poetry build
+
+        # Upload files as test artifact (to be retrieved later)
+      - uses: actions/upload-artifact@v4
+        with:
+          path: dist/*
+
+        # Publish files as release artifacts
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+
+  # If all goes well, publish to PyPI
+  publish-pypi:
+    needs: build-wheel
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download wheel and sdist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: artifact
+          path: dist
+
+      - name: Display structure of downloaded files
+        run: ls -R dist
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ keywords = [
     "natural language processing",
     "text mining",
     "biomedical literature",
-    "semantics, health data",
+    "semantics",
+    "health data"
 ]
 classifiers = ["Intended Audience :: Science/Research"]
 


### PR DESCRIPTION
I've added a CI workflow to auto-publish Autocorpus to PyPI on release, based on [the one we use for MUSE](https://github.com/EnergySystemsModellingLab/MUSE_OS/blob/main/.github/workflows/publish.yml). (I simplified it a bit though as there are some steps we don't need and I figure there's not a lot of point in trying to publish to testpypi beforehand -- either it will succeed publishing to actual PyPI or not, so I don't see what that gains us). I'm tagging @dalonsoa as I think he wrote this workflow originally.

The repo is currently not in a state where it could be published as a wheel (see #32), but we won't be making a release before this is sorted, so I think this can be reviewed now. I'll make it a draft PR anyway.

Aside from that, someone in the research team will need to set up an account on PyPI and enable [trusted publishing](https://github.com/pypa/gh-action-pypi-publish/tree/release/v1/#trusted-publishing) (if you do this, you don't need API tokens or passwords).

Closes #33.