### PR TITLE
Include data files in package

### DIFF
--- a/autocorpus/__init__.py
+++ b/autocorpus/__init__.py
@@ -1,0 +1,3 @@
+from importlib.metadata import version
+
+__version__ = version(__name__)

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -1,5 +1,6 @@
 import re
 import unicodedata
+from importlib import resources
 from pathlib import Path
 
 import bs4
@@ -71,8 +72,8 @@ def process_em(soup):
 
 def read_mapping_file():
     mapping_dict = {}
-    # TODO: dynamically find these resources to make compatible with packaging (twice more too)
-    with open("autocorpus/IAO_dicts/IAO_FINAL_MAPPING.txt", encoding="utf-8") as f:
+    mapping_path = resources.files("autocorpus.IAO_dicts") / "IAO_FINAL_MAPPING.txt"
+    with mapping_path.open(encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             heading = line.split("\t")[0].lower().strip("\n")
@@ -101,7 +102,8 @@ def read_mapping_file():
 
 def read_IAO_term_to_ID_file():
     IAO_term_to_no_dict = {}
-    with open("autocorpus/IAO_dicts/IAO_term_to_ID.txt") as f:
+    ID_path = resources.files("autocorpus.IAO_dicts") / "IAO_term_to_ID.txt"
+    with ID_path.open(encoding="utf-8") as f:
         lines = f.readlines()
         for line in lines:
             IAO_term = line.split("\t")[0]
@@ -315,7 +317,7 @@ def handle_tables(config, soup):
 
 
 def assgin_heading_by_DAG(paper):
-    G = nx.read_graphml("autocorpus/DAG_model.graphml")
+    G = nx.read_graphml(resources.files("autocorpus") / "DAG_model.graphml")
     new_mapping_dict = {}
     mapping_dict_with_DAG = {}
     IAO_term_to_no_dict = read_IAO_term_to_ID_file()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,18 @@ authors = [
 ]
 license = "GPL-3.0-only"
 readme = "README.md"
+repository = "https://github.com/omicsNLP/Auto-CORPus"
+documentation = "https://omicsnlp.github.io/Auto-CORPus/"
+keywords = [
+    "natural language processing",
+    "text mining",
+    "biomedical literature",
+    "semantics, health data",
+]
+classifiers = ["Intended Audience :: Science/Research"]
+
+[tool.poetry.urls]
+"Publication" = "https://doi.org/10.3389/fdgth.2022.788124"
 
 [tool.poetry.scripts]
 auto-corpus = "autocorpus.__main__:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "autocorpus"
-version = "1.0.0"
+version = "1.1.0"
 description = "A tool to standardise text and table data extracted from full text publications."
 authors = [
     "Tim Beck <tim.beck@nottingham.ac.uk>",


### PR DESCRIPTION
# Description

This makes it possible to run `auto-corpus` from any directory on the computer it is installed on by by getting the path for the required data files from the `importlib.resources` module.

I have not included the `configs`, `keyFiles`, and `trainedData` directories in the repo because they appear to be unused in the package itself and only used as additional inputs that can be configured via the command line arguments.

Since this is finalising the steps to make the repo package able, I have included some package metadata and updated the version number to v1.1.0 (I chose this over 1.0.1 because of the change to the main interface from removing `run_app.py`)

Fixes #32 

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
