### PR TITLE
Hackathon_BugFixes

### DIFF
--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -388,7 +388,7 @@ def handle_tables(config, soup):
                     for definition in config["data"][ele]:
                         bs_attrs = parse_configs(definition)
                         new_matches = match.find_all(
-                            bs_attrs["name"], bs_attrs["attrs"]
+                            bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None
                         )
                         if new_matches:
                             response_addition[ele] = []

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -248,7 +248,10 @@ def handle_defined_by(config, soup):
         bs_attrs = parse_configs(definition)
         new_matches = []
         if bs_attrs["name"] or bs_attrs["attrs"]:
-            new_matches = soup.find_all(bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None)
+            new_matches = soup.find_all(
+                bs_attrs["name"] if bs_attrs["name"] else None,
+                bs_attrs["attrs"] if bs_attrs["attrs"] else None,
+            )
             if new_matches:
                 new_matches = [x for x in new_matches if x.text]
         if "xpath" in bs_attrs:
@@ -307,7 +310,10 @@ def handle_not_tables(config, soup):
                 seen_text = set()
                 for definition in config["data"][ele]:
                     bs_attrs = parse_configs(definition)
-                    new_matches = match.find_all(bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None)
+                    new_matches = match.find_all(
+                        bs_attrs["name"] if bs_attrs["name"] else None,
+                        bs_attrs["attrs"] if bs_attrs["attrs"] else None,
+                    )
                     if new_matches:
                         response_addition[ele] = []
                     for newMatch in new_matches:
@@ -388,7 +394,8 @@ def handle_tables(config, soup):
                     for definition in config["data"][ele]:
                         bs_attrs = parse_configs(definition)
                         new_matches = match.find_all(
-                            bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None
+                            bs_attrs["name"] if bs_attrs["name"] else None,
+                            bs_attrs["attrs"] if bs_attrs["attrs"] else None,
                         )
                         if new_matches:
                             response_addition[ele] = []

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -248,7 +248,7 @@ def handle_defined_by(config, soup):
         bs_attrs = parse_configs(definition)
         new_matches = []
         if bs_attrs["name"] or bs_attrs["attrs"]:
-            new_matches = soup.find_all(bs_attrs["name"], bs_attrs["attrs"])
+            new_matches = soup.find_all(bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None)
             if new_matches:
                 new_matches = [x for x in new_matches if x.text]
         if "xpath" in bs_attrs:
@@ -307,7 +307,7 @@ def handle_not_tables(config, soup):
                 seen_text = set()
                 for definition in config["data"][ele]:
                     bs_attrs = parse_configs(definition)
-                    new_matches = match.find_all(bs_attrs["name"], bs_attrs["attrs"])
+                    new_matches = match.find_all(bs_attrs["name"] if bs_attrs["name"] else None, bs_attrs["attrs"] if bs_attrs["attrs"] else None)
                     if new_matches:
                         response_addition[ele] = []
                     for newMatch in new_matches:


### PR DESCRIPTION
# Description

After discovering a few issues with missing output in both legacy and current PMC files, it appears the soup.find_all function is causing issues when given an empty string. This hotfix resolves the outputs by converting these values to None.

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
