### PR TITLE
Add in infons.type for passages

### DIFF
--- a/autocorpus/bioc_passages.py
+++ b/autocorpus/bioc_passages.py
@@ -47,6 +47,17 @@ class BioCPassage:
             passage_dict["infons"][f"iao_name_{counter}"] = section_type["iao_name"]
             passage_dict["infons"][f"iao_id_{counter}"] = section_type["iao_id"]
             counter += 1
+        if passage_dict["infons"]["iao_id_1"] == "IAO:0000305":
+            passage_dict["infons"]["type"] = "front"
+        else:
+            passage_dict["infons"]["type"] = "paragraph"
+            # TODO: make optional input to AutoCORPus to have section (sub)headers a separate passage in the document.
+            # section headers:
+            # passage_dict["infons"]["type"] = "title_1"
+            # subsection headers:
+            # passage_dict["infons"]["type"] = "title_2"
+            # subsubsection headers:
+            # passage_dict["infons"]["type"] = "title_3"
 
         return passage_dict
 


### PR DESCRIPTION
# Description

_TeamTat uses the infons type to show different types of formatting. Add in the types for current BioC files (document title, passages, and references) that will render in TeamTat._

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: #110)
