### PR TITLE
Remove all commented-out code

### DIFF
--- a/autocorpus/Autocorpus.py
+++ b/autocorpus/Autocorpus.py
@@ -149,13 +149,6 @@ class Autocorpus:
         result = {}
 
         # Tags of text body to be extracted are hard-coded as p (main text) and span (keywords and refs)
-
-        # Extract title
-        # try:
-        # 	h1 = soup.find(config['title']['name'],
-        # 	               config['title']['attrs']).get_text().strip('\n')
-        # except:
-        # 	h1 = ''
         result["title"] = self.__get_title(soup, config)
         maintext = (
             self.__get_keywords(soup, config)
@@ -163,9 +156,9 @@ class Autocorpus:
             else []
         )
         sections = self.__get_sections(soup, config)
-        # sections = [x['node'] for x in sections]
         for sec in sections:
             maintext.extend(Section(config, sec).to_list())
+
         # filter out the sections which do not contain any info
         filtered_text = []
         [filtered_text.append(x) for x in maintext if x]
@@ -195,12 +188,6 @@ class Autocorpus:
                     {"iao_name": "document part", "iao_id": "IAO:0000314"}
                 ]
 
-        # uniqueText = [x for x in uniqueText if x['section_heading']]
-        # mapping_dict_with_DAG = assgin_heading_by_DAG(paper)
-        # for i, para in enumerate(uniqueText):
-        #     if para['section_heading'] in mapping_dict_with_DAG.keys():
-        #         if para['section_type'] == []:
-        #             uniqueText[i]['section_type'] = mapping_dict_with_DAG[para['section_heading']]
         return unique_text
 
     def __handle_html(self, file_path, config):

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -110,14 +110,11 @@ class Abbreviations:
                 start = start + len(candidate) - len(candidate.lstrip())
                 stop = stop - len(candidate) + len(candidate.rstrip())
                 candidate = sentence[start:stop]
-                # print (candidate)
 
                 if self.__conditions(candidate):
                     new_candidate = Candidate(candidate)
                     new_candidate.set_position(start, stop)
                     yield new_candidate
-
-    # elif LF_in_parentheses:
 
     def __get_definition(self, candidate, sentence):
         """Takes a candidate and a sentence and returns the definition candidate.The definition candidate is the set of tokens (in front of the candidate) that starts with a token starting with the first character of the candidate.
@@ -128,6 +125,7 @@ class Abbreviations:
         """
         # Take the tokens in front of the candidate
         tokens = re2.split(r"[\s\-]+", sentence[: candidate.start - 2].lower())
+
         # the char that we are looking for
         key = candidate[0].lower()
 
@@ -436,14 +434,11 @@ class Abbreviations:
             else:
                 abbrev_json[key] = {all_abbreviations[key]: ["fulltext"]}
 
-        # abbrev_json['abbreviations_section'] = author_provided_abbreviations
-        # abbrev_json['fulltext_algorithm'] = all_abbreviations
         return abbrev_json
 
     def __biocify_abbreviations(self, abbreviations, file_path):
         template = {
             "source": "Auto-CORPus (abbreviations)",
-            # "inputfile": file_path,
             "date": f"{datetime.today().strftime('%Y%m%d')}",
             "key": "autocorpus_abbreviations.key",
             "documents": [

--- a/autocorpus/references.py
+++ b/autocorpus/references.py
@@ -6,30 +6,6 @@ import re
 class References:
     """Class for processing references using an input soup object and references config."""
 
-    #
-    # def __get_section_header(self, soup_section):
-    # 	h2 = ""
-    # 	h2_select_tag = self.config['heading']['name']
-    # 	h2_select_tag += ''.join(['[{}*={}]'.format(k, self.config['heading']['attrs'][k])
-    # 	                          for k in self.config['heading']['attrs'] if self.config['heading']['attrs'][k]])
-    # 	_h2 = soup_section.select(h2_select_tag)
-    # 	if _h2:
-    # 		h2 = _h2[0].get_text().strip('\n')
-    # 	return h2
-    # 	pass
-    #
-    # def __get_subsection_header(self, soup_section):
-    # 	h3_select_tag = self.config['heading2']['name']
-    # 	h3_select_tag += ''.join(['[{}*={}]'.format(k, self.config['heading2']['attrs'][k])
-    # 	                          for k in self.config['heading2']['attrs'] if self.config['heading2']['attrs'][k]])
-    # 	h3 = soup_section.select(h3_select_tag)
-    # 	if h3:
-    # 		h3 = h3[0].get_text().strip('\n')
-    # 	else:
-    # 		h3 = ''
-    # 	return h3
-    # 	pass
-
     def __create_reference_block(self, reference):
         text = reference["node"].get_text().replace("Go to:", "").replace("\n", "")
         text = re.sub(r"\s{2,}", " ", text)

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -18,29 +18,6 @@ from .utils import handle_not_tables, read_iao_term_to_id_file, read_mapping_fil
 class Section:
     """Class for processing section data."""
 
-    # def __get_section_header(self, soup_section):
-    #
-    # 	# if "sectionsNew" in config:
-    # 	h2 = ""
-    # 	h2_select_tag = self.config['heading']['name']
-    # 	h2_select_tag += ''.join(['[{}*={}]'.format(k, self.config['heading']['attrs'][k])
-    # 	                          for k in self.config['heading']['attrs'] if self.config['heading']['attrs'][k]])
-    # 	_h2 = soup_section.select(h2_select_tag)
-    # 	if _h2:
-    # 		h2 = _h2[0].get_text().strip('\n')
-    # 	return h2
-
-    # def __get_subsection_header(self, soup_section):
-    # 	h3_select_tag = self.config['heading2']['name']
-    # 	h3_select_tag += ''.join(['[{}*={}]'.format(k, self.config['heading2']['attrs'][k])
-    #                           for k in self.config['heading2']['attrs'] if self.config['heading2']['attrs'][k]])
-    # 	h3 = soup_section.select(h3_select_tag)
-    # 	if h3:
-    # 		h3 = h3[0].get_text().strip('\n')
-    # 	else:
-    # 		h3 = ''
-    # 	return h3
-
     def __add_paragraph(self, body):
         self.paragraphs.append(
             {
@@ -68,8 +45,7 @@ class Section:
                     if "headers" in subsec and not subsec["headers"] == ""
                     else ""
                 )
-        # elif soup_section in subsecNodes:
-        # 	self.subheader = self.__get_subsection_header(soup_section)
+
         try:
             children = soup_section.findChildren(recursive=False)
         except Exception as e:
@@ -97,8 +73,6 @@ class Section:
         mapping_dict = read_mapping_file()
         tokenized_section_heading = nltk.wordpunct_tokenize(self.section_heading)
         text = nltk.Text(tokenized_section_heading)
-        ## this .isalpha() should probably be removed as it;s stripping out &
-        # words = [w.lower() for w in text if w.isalpha()]
         words = [w.lower() for w in text]
         h2_tmp = " ".join(word for word in words)
 
@@ -138,10 +112,6 @@ class Section:
         paper = {}
         iao_term = iao_term
         paper.update({self.section_heading: iao_term})
-        # mapping_dict_with_DAG = assgin_heading_by_DAG(paper)
-        #
-        # if self.section_heading in mapping_dict_with_DAG.keys():
-        # 	IAO_term = mapping_dict_with_DAG[self.section_heading]
 
         # map IAO terms to IAO IDs
         iao_term_to_no_dict = read_iao_term_to_id_file()
@@ -159,15 +129,11 @@ class Section:
         all_tables = [x["node"] for x in all_tables]
         all_figures = handle_not_tables(self.config["figures"], soup_section)
         all_figures = [x["node"] for x in all_figures]
-        # all_sub_sections = soup_section.find_all(self.config['subsections']['name'], self.config['subsections']['attrs'])
-        # all_paragraphs = soup_section.find_all(self.config['paragraphs']['name'])
-        # all_tables = soup_section.find_all(self.config['table-container']['name'], self.config['table-container']['attrs'])
         unwanted_paragraphs = []
         [
             unwanted_paragraphs.extend(capt.find_all("p", recursive=True))
             for capt in all_tables
         ]
-        # all_figures = soup_section.find_all(self.config["figure"]["name"], self.config['figure']['attrs'])
         [
             unwanted_paragraphs.extend(capt.find_all("p", recursive=True))
             for capt in all_figures
@@ -175,17 +141,6 @@ class Section:
         all_paragraphs = [
             para for para in all_paragraphs if para not in unwanted_paragraphs
         ]
-        # if self.config['paragraphs']['regex'] is not None:
-        # 	for para in all_paragraphs:
-        # 		success=True
-        # 		for rePattern in self.config['paragraphs']['regex']:
-        # 			if para.has_attr(rePattern['attrs']):
-        # 				if not re.match(rePattern['regex'], para.get(rePattern['attrs'])):
-        # 					success=False
-        # 			else:
-        # 				success=False
-        # 		if success:
-        # 			filtered_paragraphs.append(para)
         children = soup_section.findChildren(recursive=False)
         for child in children:
             self.__navigate_children(child, all_sub_sections, all_paragraphs)

--- a/autocorpus/table.py
+++ b/autocorpus/table.py
@@ -54,22 +54,14 @@ class Table:
                 # fill table data
                 rowspan = rowspans[col_idx] = int(cell.attrs["rowspan"])
                 colspan = int(cell.attrs["colspan"])
+
                 # next column is offset by the colspan
                 span_offset += colspan - 1
-                # value = ''.join(str(x) for x in cell.get_text())
                 c_cont = cell.contents
                 value = ""
                 for item in c_cont:
                     value += navigate_contents(item)
-                # if isinstance(item, bs4.element.NavigableString):
-                # 	value += item + " "
-                # if isinstance(item, bs4.element.Tag):
-                # 	if item.name == "sup" or item.name == "sub":
-                # 		value += "<" + item.name + ">"
-                # 		value += item.get_text()
-                # 		value += "</" + item.name + ">"
-                # 	else:
-                # 		value += item.get_text()
+
                 # clean the cell
                 value = value.strip().replace("\u2009", " ").replace("&#x000a0;", " ")
                 value = re.sub(r"\s", " ", value)
@@ -91,6 +83,7 @@ class Table:
                     except IndexError:
                         # rowspan or colspan outside the confines of the table
                         pass
+
             # update rowspan bookkeeping
             rowspans = {c: s - 1 for c, s in rowspans.items() if s > 1}
         return table
@@ -127,7 +120,7 @@ class Table:
         """
         if header == "":
             return None
-        #     parts = nltk.tokenize.word_tokenize(header)
+
         a = re.split(r"[:|/,;]", header)
         b = re.findall(r"[:|/,;]", header)
         parts = []

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -41,7 +41,6 @@ def process_supsub(soup):
         soup: BeautifulSoup object of html
 
     """
-    # for sup in soup.find_all(['sup', 'sub']):
     for sup in soup.find_all("sub"):
         s = sup.get_text()
         if sup.string is None:
@@ -406,7 +405,8 @@ def handle_tables(config, soup):
                                 value = ""
                                 for item in newMatch.contents:
                                     value += navigate_contents(item)
-                                    # clean the cell
+
+                                # clean the cell
                                 value = value.strip().replace("\u2009", " ")
                                 value = re.sub("<\\/?span[^>\n]*>?|<hr\\/>?", "", value)
                                 value = re.sub("\\n", "", value)


### PR DESCRIPTION
# Description

I've gone through and removed all the commented-out code so that when we're doing further tidying/development we're not tripping over it.

I'm *assuming* that none of it's actually used, but if any of it is used for debugging let me know. If there's extra info that is useful to print out during debugging, it's best to use a logger for that anyway rather than having commented out code (see also #134), but we can always do that if needed.

Closes #137.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
