### PR TITLE
Enforce Pydocstyle

### DIFF
--- a/autocorpus/parse_xml.py
+++ b/autocorpus/parse_xml.py
@@ -1,3 +1,12 @@
+"""A script for running an XML parser version of Auto-CORPus.
+
+This is still experimental and under development and is not part of the main too yet.
+
+To use it run:
+
+`python -m autocorpus.parse_xml <path_to_directory_containing_xml_files>`
+"""
+
 import glob
 import json
 import re
@@ -5,11 +14,19 @@ from datetime import datetime
 
 import nltk
 import numpy as np
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, NavigableString, ResultSet, Tag
 from fuzzywuzzy import fuzz
 
 
-def replace_spaces_and_newlines(input_string):
+def replace_spaces_and_newlines(input_string: str) -> str:
+    """Replace multiple spaces and newline characters in a string with a single space.
+
+    Args:
+        input_string: The input string.
+
+    Returns:
+        The updated string.
+    """
     # Replace multiple spaces (2 or more) with a single space
     input_string = re.sub(r" {2,}", " ", input_string)
 
@@ -20,7 +37,16 @@ def replace_spaces_and_newlines(input_string):
     return input_string
 
 
-def replace_match(match):
+def _replace_match(match: re.Match) -> str:
+    """Get the Unicode character corresponding to the escape sequence in a regex match.
+
+    Args:
+        match: The regular expression match object.
+            Must contain a Unicode escape sequence.
+
+    Returns:
+        The unicode character corresponding to the escape sequence.
+    """
     # Extract the Unicode escape sequence (e.g., \uXXXX)
     unicode_escape = match.group(0)
 
@@ -31,19 +57,32 @@ def replace_match(match):
     return unicode_char
 
 
-def replace_unicode_escape(input_string):
+def replace_unicode_escape(input_string: str):
+    """Find and replace unicode escape sequences with the actual characters in a string.
+
+    Args:
+        input_string: The input string containing Unicode escape sequences.
+
+    Returns:
+        The updated string with Unicode escape sequences replaced by actual characters.
+    """
     # Use a regular expression to find all Unicode escape sequences (e.g., \uXXXX)
     pattern = re.compile(r"\\u[0-9a-fA-F]{4}")
     # Replace Unicode escape sequences with actual characters
-    output_string = pattern.sub(replace_match, input_string)
+    output_string = pattern.sub(_replace_match, input_string)
 
     # Return the result
     return output_string
 
 
-def read_mapping_file():
+def read_mapping_file() -> dict:
+    """Read the IAO mapping file and create a dictionary of IAO terms and headings.
+
+    Returns:
+        A dictionary mapping IAO terms to their corresponding headings.
+    """
     # Initialize an empty dictionary to store the mapping between IAO terms and headings
-    mapping_dict = {}
+    mapping_dict: dict = {}
 
     # Open the mapping file in read mode
     with open("./data/IAO_FINAL_MAPPING.txt", encoding="utf-8") as f:
@@ -89,6 +128,11 @@ def read_mapping_file():
 
 
 def read_IAO_term_to_ID_file():
+    """Read the IAO term to ID mapping file and create a dictionary of IAO terms and IDs.
+
+    Returns:
+        A dictionary mapping IAO terms to their corresponding IDs.
+    """
     # Initialize an empty dictionary to store the mapping between IAO terms and their corresponding IDs
     IAO_term_to_no_dict = {}
 
@@ -137,7 +181,18 @@ def __add_IAO(section_heading, IAO_term):
     }
 
 
-def extract_section_content(section, soup2, ori_title):
+def extract_section_content(
+    section: ResultSet,
+    soup2: BeautifulSoup,
+    ori_title: str,
+):
+    """Extract the content of a section and its subsections recursively.
+
+    Args:
+        section: A BeautifulSoup ResultSet object representing a section of the document.
+        soup2: A BeautifulSoup object representing the entire document.
+        ori_title: The original title of the section.
+    """
     # Extract the current section's title, or use the original title if none is found
     curren_title = section.find("title")
     if curren_title is None:  # If no title is found, fall back to the original title
@@ -191,9 +246,18 @@ def extract_section_content(section, soup2, ori_title):
         extract_section_content(subsection, soup2, ori_title)
 
 
-def find_parent_titles(title_element):
+def find_parent_titles(title_element: Tag | NavigableString) -> list[str]:
+    """Find the parent titles of a given title element in the document hierarchy.
+
+    Args:
+        title_element: A BeautifulSoup Tag or NavigableString object representing a
+            title element.
+
+    Returns:
+        A list of parent titles in the document hierarchy.
+    """
     # Initialize an empty list to store parent titles
-    parent_titles = []
+    parent_titles: list[str] = []
 
     # Find the immediate parent <sec> element of the given title element
     parent = title_element.find_parent(["sec"])

--- a/autocorpus/tableimage.py
+++ b/autocorpus/tableimage.py
@@ -1,3 +1,8 @@
+"""This module contains the TableImage class.
+
+Which is used to extract tables from images and save them in a json format.
+"""
+
 from datetime import datetime
 from operator import itemgetter
 from pathlib import Path
@@ -7,10 +12,20 @@ import pytesseract
 
 
 class TableImage:
+    """Class to extract tables from images and save them in a json format."""
+
     def img2text(self, img, x, y, w, h):
-        """Function: translate image into texts
-        Input: original image, and location of text boxes
-        Output: extracted texts
+        """Translate an image into texts.
+
+        Args:
+            img: original image
+            x: The x position of the text boxes
+            y: The y position of the text boxes
+            w: The width of the text boxes
+            h: The height of the text boxes
+
+        Returns:
+            The extracted texts.
         """
         roi = img[y - 3 : (y + h + 6), x - 3 : (x + w + 6)]
 
@@ -22,9 +37,13 @@ class TableImage:
         return new_text
 
     def rm_lines(self, img):
-        """Function: remove all the horizontal and vertical lines in image and binary it
-        Input: original image
-        Output: image after preprocessing
+        """Remove all the horizontal and vertical lines in image and binary it.
+
+        Args:
+            img: The original image
+
+        Returns:
+            The image after preprocessing
         """
         gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
         binary = cv2.adaptiveThreshold(
@@ -51,9 +70,13 @@ class TableImage:
         return after
 
     def find_cells(self, img):
-        """Function: find cells in table images and sort them from top-left to bottom-right
-        Input: original image
-        Output: ordered table cells, and processed image
+        """Find cells in table images and sort them from top-left to bottom-right.
+
+        Args:
+            img: The original image
+
+        Returns:
+            The ordered table cells, and processed image
         """
         added = cv2.copyMakeBorder(
             img, 10, 10, 10, 10, cv2.BORDER_CONSTANT, value=[255, 255, 255]
@@ -111,9 +134,20 @@ class TableImage:
         return cells, added, thresh
 
     def cell2table(self, cells, added, thresh, target_dir, pmc):
-        """Function: save table texts in several rows
-        Input: ordered table cells, and processed image
-        Output: table text saved line by line
+        """Save table texts in several rows.
+
+        TODO: Two of the input arguments are not used and there is no distinction
+        between the `added` image and the `thresh` image.
+
+        Args:
+            cells: The ordered table cells
+            added: processed image
+            thresh: processed image
+            target_dir: unused
+            pmc: unused
+
+        Returns:
+            The table text saved line by line
         """
         # after sort, read cells line by line
         color = (0, 255, 0)  # box color
@@ -145,9 +179,12 @@ class TableImage:
         return table_row
 
     def text2json(self, table_row):
-        """Function: save table into a formatted json file
-        Input: table text saved line by line
-        Output: formatted json file of tables
+        """Save table into a formatted json file.
+
+        Args:
+            table_row: The table text saved line by line
+        Returns:
+            The formatted json file of tables
         """
         identifier = ""
         title = ""
@@ -319,6 +356,13 @@ class TableImage:
         return table_dict
 
     def __init__(self, table_images, base_dir, trained_data="eng"):
+        """Construct the TableImage object.
+
+        Args:
+            table_images: list of paths to table images
+            base_dir: the base directory
+            trained_data: The trained data language. Defaults to "eng".
+        """
         self.trainedData = trained_data
         self.table_raw = []
         self.tables = {
@@ -345,4 +389,9 @@ class TableImage:
             )
 
     def to_dict(self):
+        """Return the tables dictionary.
+
+        Returns:
+            The tables dictionary
+        """
         return self.tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ keywords = [
     "text mining",
     "biomedical literature",
     "semantics",
-    "health data"
+    "health data",
 ]
 classifiers = ["Intended Audience :: Science/Research"]
 
@@ -68,6 +68,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
+    "D",   # pydocstyle
     "E",   # pycodestyle
     "F",   # Pyflakes
     "I",   # isort
@@ -80,3 +81,4 @@ ignore = [
     "RUF001", # ambiguous multiplication sign
     "RUF003", # ambiguous fullwidth colon
 ]
+pydocstyle.convention = "google"


### PR DESCRIPTION
# Description

This PR enforces google style docstrings throughout the code for the ruff linter checks to pass.

I have needed to make my best-guess for describing what some of the functions and arguments are. Please confirm these make sense.

Fixes #130 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
