### PR TITLE
Add some more files to `.gitignore` and some default VS Code settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Auto-CORPus output files
+autoCORPus-log-*
+*_abbreviations.json
+*_bioc.json
+*_tables.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: pretty-format-json
         args: [--autofix, --indent, '4', --no-sort]
+        exclude: ^\.vscode/
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
     rev: v2.14.0
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "davidanson.vscode-markdownlint",
+        "charliermarsh.ruff"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Auto-CORPus with PMC config",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "autocorpus",
+      "args": [
+        "-c",
+        "${workspaceFolder}/autocorpus/configs/config_pmc.json",
+        "-t",
+        "output",
+        "-f",
+        "${workspaceFolder}/tests/data/PMC/Current/PMC8885717.html"
+      ]
+    },
+    {
+      "name": "Run Auto-CORPus with legacy PMC config",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "autocorpus",
+      "args": [
+        "-c",
+        "${workspaceFolder}/autocorpus/configs/config_pmc_pre_oct_2024.json",
+        "-t",
+        "output",
+        "-f",
+        "${workspaceFolder}/tests/data/PMC/Pre-Oct-2024/PMC8885717.html"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "[python]": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "charliermarsh.ruff"
+    },
+    "editor.rulers": [
+        88
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "editor.formatOnSave": false
+}

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+# Auto-generated API documentation
+reference/

--- a/tests/data/.gitignore
+++ b/tests/data/.gitignore
@@ -1,0 +1,4 @@
+# Don't ignore output files in this folder as they are used for regression tests
+!*_abbreviations.json
+!*_bioc.json
+!*_tables.json


### PR DESCRIPTION
# Description

While developing I've found that I end up with my work tree cluttered with various output files etc. that aren't being ignored by git, making it hard to see what I've actually added/changed (there is also this issue: #155).

The contents of the `.vscode` folder are also not being ignored. Instead of ignoring these files though, I thought I'd just add some sensible default settings and some debug configs for convenience. Some people hate having editor settings committed to their repo though, so if you'd rather not have this stuff we can just add this folder to `.gitignore`.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
