### PR TITLE
`pytest`: Ignore `site/` folder

### DIFF
--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -4,29 +4,36 @@ from pathlib import Path
 
 import mkdocs_gen_files
 
-nav = mkdocs_gen_files.Nav()
 
-for path in sorted(Path("autocorpus").glob("**/*.py")):
-    module_path = path.relative_to(".").with_suffix("")
-    doc_path = path.relative_to(".").with_suffix(".md")
-    full_doc_path = Path("reference", doc_path)
+def main():
+    """Generate references."""
+    nav = mkdocs_gen_files.Nav()
 
-    parts = list(module_path.parts)
-    if ".array_cache" in parts:
-        continue
-    elif parts[-1] == "__init__":
-        parts = parts[:-1]
-        doc_path = doc_path.with_name("index.md")
-        full_doc_path = full_doc_path.with_name("index.md")
-    elif parts[-1] == "__main__":
-        continue
-    nav[parts] = doc_path
+    for path in sorted(Path("autocorpus").glob("**/*.py")):
+        module_path = path.relative_to(".").with_suffix("")
+        doc_path = path.relative_to(".").with_suffix(".md")
+        full_doc_path = Path("reference", doc_path)
 
-    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-        ident = ".".join(parts)
-        print("::: " + ident, file=fd)
+        parts = list(module_path.parts)
+        if ".array_cache" in parts:
+            continue
+        elif parts[-1] == "__init__":
+            parts = parts[:-1]
+            doc_path = doc_path.with_name("index.md")
+            full_doc_path = full_doc_path.with_name("index.md")
+        elif parts[-1] == "__main__":
+            continue
+        nav[parts] = doc_path
 
-    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+        with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+            ident = ".".join(parts)
+            print("::: " + ident, file=fd)
 
-with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
-    nav_file.writelines(nav.build_literate_nav())
+        mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
+
+    with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+        nav_file.writelines(nav.build_literate_nav())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
-addopts = "-v -p no:warnings --cov=autocorpus --cov-report=html --doctest-modules --ignore=run_app.py --ignore=docs/"
+addopts = "-v -p no:warnings --cov=autocorpus --cov-report=html --doctest-modules --ignore=docs/ --ignore=site/"
 
 [tool.ruff]
 target-version = "py310"


### PR DESCRIPTION
# Description

I finally figured out why I was seeing #155 on one machine but not the other. It seems that at some point I must have run `mkdocs build` which creates a `site` folder containing a *copy* of the `gen_ref_nav.py` script. `pytest` wasn't set to ignore this folder so it was being run every time `pytest` was invoked, but only on the machine where this folder exists. It also explains why adding the `if __name__ == "__main__"` block to the copy of `gen_ref_nav.py` in `docs/` didn't fix it. I finally figured it out by `chown`ing the `docs/references/` folder to `root` so I got a permission error when I ran `pytest`.

Adding that `if __name__ ...` block to the script would also presumably have worked if I'd rerun `mkdocs build` after. I've made this change too, even though it isn't strictly necessary, just to avoid these sorts of problems in future.

Fixes #155.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
