### PR TITLE
Use Python's `logging` module for writing to console and file

### DIFF
--- a/autocorpus/Autocorpus.py
+++ b/autocorpus/Autocorpus.py
@@ -38,16 +38,13 @@ class Autocorpus:
 
     def __soupify_infile(self, fpath):
         fpath = Path(fpath)
-        try:
-            with open(fpath, encoding="utf-8") as fp:
-                soup = BeautifulSoup(fp.read(), "html.parser")
-                for e in soup.find_all(
-                    attrs={"style": ["display:none", "visibility:hidden"]}
-                ):
-                    e.extract()
-                return soup
-        except Exception as e:
-            print(e)
+        with fpath.open(encoding="utf-8") as fp:
+            soup = BeautifulSoup(fp.read(), "html.parser")
+            for e in soup.find_all(
+                attrs={"style": ["display:none", "visibility:hidden"]}
+            ):
+                e.extract()
+            return soup
 
     def __get_keywords(self, soup, config):
         if "keywords" in config:

--- a/autocorpus/Autocorpus.py
+++ b/autocorpus/Autocorpus.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from bioc import biocjson, biocxml
 from bs4 import BeautifulSoup
 
+from . import logger
 from .abbreviation import Abbreviations
 from .bioc_formatter import BiocFormatter
 from .section import Section
@@ -316,7 +317,7 @@ class Autocorpus:
                     self.main_text, soup, self.config, self.file_path
                 ).to_dict()
             except Exception as e:
-                print(e)
+                logger.error(e)
         if self.linked_tables:
             for table_file in self.linked_tables:
                 soup = self.__handle_html(table_file, self.config)

--- a/autocorpus/__init__.py
+++ b/autocorpus/__init__.py
@@ -13,16 +13,23 @@ def create_logger():
 
     # create console handler
     ch = logging.StreamHandler()
-
-    # create formatter and add it to the handlers
-    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
-    ch.setFormatter(formatter)
+    ch.setFormatter(_log_formatter)
 
     # add the handlers to the logger
     logger.addHandler(ch)
 
     return logger
 
+
+def add_file_logger(file_path):
+    """Add a log handler to write log messages to file."""
+    # same format as used for console
+    fh = logging.FileHandler(file_path)
+    fh.setFormatter(_log_formatter)
+    logger.addHandler(fh)
+
+
+_log_formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
 
 logger = create_logger()
 """The logger for the Auto-CORPus module and command-line program."""

--- a/autocorpus/__init__.py
+++ b/autocorpus/__init__.py
@@ -1,5 +1,28 @@
 """AutoCorpus package."""
 
+import logging
 from importlib.metadata import version
 
 __version__ = version(__name__)
+
+
+def create_logger():
+    """Create a logger for the program with default settings."""
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+
+    # create console handler
+    ch = logging.StreamHandler()
+
+    # create formatter and add it to the handlers
+    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
+    ch.setFormatter(formatter)
+
+    # add the handlers to the logger
+    logger.addHandler(ch)
+
+    return logger
+
+
+logger = create_logger()
+"""The logger for the Auto-CORPus module and command-line program."""

--- a/autocorpus/__main__.py
+++ b/autocorpus/__main__.py
@@ -7,8 +7,9 @@ from pathlib import Path
 
 from tqdm import tqdm
 
-from autocorpus.Autocorpus import Autocorpus
-from autocorpus.configs.default_config import DefaultConfig
+from . import logger
+from .Autocorpus import Autocorpus
+from .configs.default_config import DefaultConfig
 
 parser = argparse.ArgumentParser(prog="PROG")
 parser.add_argument(
@@ -61,7 +62,9 @@ def get_file_type(file_path: Path) -> str:
             return "linked_tables"
         return "main_text"
 
-    print(f"unable to identify file type for {file_path}, file will not be processed")
+    logger.warning(
+        f"unable to identify file type for {file_path}, file will not be processed"
+    )
     return ""
 
 
@@ -116,7 +119,7 @@ def read_file_structure(file_path: Path, target_dir: Path):
                 structure = fill_structure(structure, base_file, "linked_tables", fpath)
                 structure = fill_structure(structure, base_file, "out_dir", out_dir)
             elif not ftype:
-                print(
+                logger.warning(
                     f"cannot determine file type for {fpath}. "
                     "AC will not process this file"
                 )
@@ -250,7 +253,7 @@ def main():
         log_file.write("\n".join(success) + "\n")
         log_file.write("\n".join(errors) + "\n")
         if errors:
-            print(
+            logger.warning(
                 "Auto-CORPus has completed processing with some errors. "
                 "Please inspect the log file for further details."
             )

--- a/autocorpus/__main__.py
+++ b/autocorpus/__main__.py
@@ -189,9 +189,9 @@ def main():
         f"Auto-CORPus log file from {cdate.hour}:{cdate.minute} "
         f"on {cdate.day}/{cdate.month}/{cdate.year}"
     )
-    logger.info(f"Input directory provided: {file_path}")
-    logger.info(f"Output directory provided: {target_dir}")
-    logger.info(f"Config provided: {config}")
+    logger.info(f"Input path: {file_path}")
+    logger.info(f"Output path: {target_dir}")
+    logger.info(f"Config: {config}")
     logger.info(f"Output format: {output_format}")
     success = []
     errors = []

--- a/autocorpus/__main__.py
+++ b/autocorpus/__main__.py
@@ -1,14 +1,13 @@
 """Main entry script for the autocorpus CLI."""
 
 import argparse
-import logging
 import re
 from datetime import datetime
 from pathlib import Path
 
 from tqdm import tqdm
 
-from . import logger
+from . import add_file_logger, logger
 from .Autocorpus import Autocorpus
 from .configs.default_config import DefaultConfig
 
@@ -148,15 +147,6 @@ def read_file_structure(file_path: Path, target_dir: Path):
         file_path if get_file_type(file_path) == "main_text" else [file_path]
     )
     return template
-
-
-def add_file_logger(file_path):
-    """Add a log handler to write log messages to file."""
-    # same format as used for console
-    formatter = logging.Formatter("%(asctime)s [%(levelname)s] %(message)s")
-    fh = logging.FileHandler(file_path)
-    fh.setFormatter(formatter)
-    logger.addHandler(fh)
 
 
 def main():

--- a/autocorpus/__main__.py
+++ b/autocorpus/__main__.py
@@ -171,7 +171,7 @@ def main():
 
     log_file_path = (
         target_dir / "autoCORPus-log-"
-        f"{cdate.day}-{cdate.month}-{cdate.year}-{cdate.hour}-{cdate.minute}"
+        f"{cdate.day}-{cdate.month}-{cdate.year}-{cdate.hour}-{cdate.minute}.log"
     )
 
     with log_file_path.open("w") as log_file:

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -8,12 +8,13 @@ modules used:
 - regex: regular expression matching/replacing
 """
 
-import logging
 from collections import Counter, defaultdict
 from datetime import datetime
 from pathlib import Path
 
 import regex as re2
+
+from . import logger
 
 
 class Abbreviations:
@@ -270,7 +271,7 @@ class Abbreviations:
                     try:
                         definition = self.__get_definition(candidate, clean_sentence)
                     except (ValueError, IndexError) as e:
-                        self.log.debug(
+                        logger.debug(
                             f"{i} Omitting candidate {candidate}. Reason: {e.args[0]}"
                         )
                         omit += 1
@@ -278,7 +279,7 @@ class Abbreviations:
                         try:
                             definition = self.__select_definition(definition, candidate)
                         except (ValueError, IndexError) as e:
-                            self.log.debug(
+                            logger.debug(
                                 f"{i} Omitting definition {definition} for candidate {candidate}. Reason: {e.args[0]}"
                             )
                             omit += 1
@@ -291,8 +292,8 @@ class Abbreviations:
                                 abbrev_map[candidate] = definition
                             written += 1
             except (ValueError, IndexError) as e:
-                self.log.debug(f"{i} Error processing sentence {sentence}: {e.args[0]}")
-        self.log.debug(f"{written} abbreviations detected and kept ({omit} omitted)")
+                logger.debug(f"{i} Error processing sentence {sentence}: {e.args[0]}")
+        logger.debug(f"{written} abbreviations detected and kept ({omit} omitted)")
 
         # Return most common definition for each term
         if collect_definitions:
@@ -471,15 +472,9 @@ class Abbreviations:
             config (dict): AC configuration rules
             file_path (str): Input file path
         """
-        logging.basicConfig(
-            format="%(asctime)s : %(levelname)s : %(message)s", level=logging.INFO
-        )
-        self.log = logging.getLogger(__name__)
-
         self.abbreviations = self.__biocify_abbreviations(
             self.__get_abbreviations(main_text, soup, config), file_path
         )
-        pass
 
     def to_dict(self):
         """Retrieves abbreviations BioC dict.

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -11,6 +11,7 @@ import re
 import nltk
 from fuzzywuzzy import fuzz
 
+from . import logger
 from .references import References
 from .utils import handle_not_tables, read_iao_term_to_id_file, read_mapping_file
 
@@ -49,7 +50,7 @@ class Section:
         try:
             children = soup_section.findChildren(recursive=False)
         except Exception as e:
-            print(e)
+            logger.warning(e)
             children = []
         for child in children:
             self.__navigate_children(child, all_sub_sections, filtered_paragraphs)


### PR DESCRIPTION
# Description

Currently the code writes log messages to both the console and a log file, using `print()` statements for the former and manually writing messages to file for the latter. I've changed things so that the `logging` package is used consistently everywhere in the codebase.

I decided to log the same messages to console and file although, if you don't like this, we can change the verbosity of one or the other (e.g. we could have extra messages that are written only to file by using the log level `DEBUG`). I felt like the console output was a bit lacking and a lot of the information that goes to the log file (e.g. details of errors) would also be useful to see on the console. Equally, I think any information that's printed to the console also ought to be written to the log file.

Example output:

```
2025-03-25 16:37:45,754 [INFO] Auto-CORPus log file from 16:37 on 25/3/2025
2025-03-25 16:37:45,754 [INFO] Input path: tests/data/PMC/Current/PMC8885717.html
2025-03-25 16:37:45,754 [INFO] Output path: output
2025-03-25 16:37:45,754 [INFO] Config: autocorpus/configs/config_pmc.json
2025-03-25 16:37:45,754 [INFO] Output format: JSON
100%|█████████████████████████████████| 1/1 [00:00<00:00,  3.15it/s, file=PMC8885717*, linked_tables=0]
2025-03-25 16:37:46,071 [INFO] 1 files processed.
2025-03-25 16:37:46,071 [INFO] PMC8885717 was processed successfully.
```

If you don't want timestamps associated with every message (or only want them in the log file -- we can use different formats for each), please say.

This work is kind of a precursor to #131. There are a lot of places where exceptions are just caught and printed out and, for now, I've just converted them to logging statements. Eventually we will want to put the `try`/`except` blocks in slightly more considered places because they seem to be a bit ad hoc right now (e.g. there's no point catching an exception and printing it out if the code doesn't actually recover from the error and *another* exception is thrown as soon as it tries to use a non-existent return value). Anyway, that's a job for another day.

There's currently no way for users to change the log level at runtime (e.g. to see debug messages), but that might be a good idea. Maybe we could add another command-line flag. Happy to do that if desired.

Closes #134.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
