### PR TITLE
IAO default allocation

### DIFF
--- a/autocorpus/parse_xml.py
+++ b/autocorpus/parse_xml.py
@@ -1233,7 +1233,7 @@ if __name__ == "__main__":
 
             mapping_dict = read_mapping_file()
 
-            # Main body IAO allocation 
+            # Main body IAO allocation
             iao_list = []
 
             for y in range(len(corrected_section)):
@@ -1278,25 +1278,27 @@ if __name__ == "__main__":
 
                     # if condition to add the default value 'document part' for passages without IAO
                     if mapping_result == []:
-                        section_type = [{
-                            "iao_name": 'document part', # Name of the IAO term
-                            "iao_id": 'IAO:0000314'  # ID associated with the IAO term, or empty if not found
-                        }]
+                        section_type = [
+                            {
+                                "iao_name": "document part",  # Name of the IAO term
+                                "iao_id": "IAO:0000314",  # ID associated with the IAO term, or empty if not found
+                            }
+                        ]
                     else:
                         section_type = mapping_result
 
-                iao_list.append(
-                    list({v["iao_id"]: v for v in section_type}.values())
-                )
+                iao_list.append(list({v["iao_id"]: v for v in section_type}.values()))
 
-            # References IAO allocation 
+            # References IAO allocation
             iao_list_ref = []
-            
+
             for y in range(len(tag_title_ref)):
-                section_type = [{
-                    "iao_name": 'References', # Name of the IAO term
-                    "iao_id": 'IAO:0000320'  # ID associated with the IAO term, or empty if not found
-                }]
+                section_type = [
+                    {
+                        "iao_name": "References",  # Name of the IAO term
+                        "iao_id": "IAO:0000320",  # ID associated with the IAO term, or empty if not found
+                    }
+                ]
 
                 iao_list_ref.append(
                     list({v["iao_id"]: v for v in section_type}.values())

--- a/autocorpus/parse_xml.py
+++ b/autocorpus/parse_xml.py
@@ -1232,6 +1232,8 @@ if __name__ == "__main__":
             ######### FROM AC MAIN LIBRARY #########
 
             mapping_dict = read_mapping_file()
+
+            # Main body IAO allocation 
             iao_list = []
 
             for y in range(len(corrected_section)):
@@ -1273,51 +1275,28 @@ if __name__ == "__main__":
                                         )
                     else:
                         mapping_result = []
-                    section_type = mapping_result
 
-                iao_list.append(list({v["iao_id"]: v for v in section_type}.values()))
-
-            iao_list_ref = []
-            for y in range(len(tag_title_ref)):
-                if tag_title_ref[y][0] == "document title":
-                    section_type = [
-                        {"iao_name": "document title", "iao_id": "IAO:0000305"}
-                    ]
-                else:
-                    tokenized_section_heading = nltk.wordpunct_tokenize(
-                        tag_title_ref[y][0]
-                    )
-                    text = nltk.Text(tokenized_section_heading)
-                    words = [w.lower() for w in text]
-                    h2_tmp = " ".join(word for word in words)
-
-                    # TODO: check for best match, not the first
-                    if h2_tmp != "":
-                        if any(x in h2_tmp for x in [" and ", "&", "/"]):
-                            mapping_result = []
-                            h2_parts = re.split(r" and |\s?/\s?|\s?&\s?", h2_tmp)
-                            for h2_part in h2_parts:
-                                h2_part = re.sub(r"^\d*\s?[\(\.]]?\s?", "", h2_part)
-                                pass
-                                for IAO_term, heading_list in mapping_dict.items():
-                                    for i in range(len(heading_list)):
-                                        if fuzz.ratio(h2_part, heading_list[i]) > 80:
-                                            mapping_result.append(
-                                                __add_IAO(heading_list[i], IAO_term)
-                                            )
-
-                        else:
-                            mapping_result = []
-                            for IAO_term, heading_list in mapping_dict.items():
-                                h2_tmp = re.sub(r"^\d*\s?[\(\.]]?\s?", "", h2_tmp)
-                                for i in range(len(heading_list)):
-                                    if fuzz.ratio(h2_tmp, heading_list[i]) > 80:
-                                        mapping_result.append(
-                                            __add_IAO(heading_list[i], IAO_term)
-                                        )
+                    # if condition to add the default value 'document part' for passages without IAO
+                    if mapping_result == []:
+                        section_type = [{
+                            "iao_name": 'document part', # Name of the IAO term
+                            "iao_id": 'IAO:0000314'  # ID associated with the IAO term, or empty if not found
+                        }]
                     else:
-                        mapping_result = []
-                    section_type = mapping_result
+                        section_type = mapping_result
+
+                iao_list.append(
+                    list({v["iao_id"]: v for v in section_type}.values())
+                )
+
+            # References IAO allocation 
+            iao_list_ref = []
+            
+            for y in range(len(tag_title_ref)):
+                section_type = [{
+                    "iao_name": 'References', # Name of the IAO term
+                    "iao_id": 'IAO:0000320'  # ID associated with the IAO term, or empty if not found
+                }]
 
                 iao_list_ref.append(
                     list({v["iao_id"]: v for v in section_type}.values())

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -107,7 +107,13 @@ class Section:
                         mapping_result = []
         else:
             mapping_result = []
-        self.section_type = mapping_result
+        if mapping_result == []:
+            self.section_type = [{
+                                    "iao_name": 'document part',      
+                                    "iao_id": 'IAO:0000314'
+                                }]
+        else:
+            self.section_type = mapping_result
 
     def __add_iao(self, iao_term):
         paper = {}

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -108,10 +108,7 @@ class Section:
         else:
             mapping_result = []
         if mapping_result == []:
-            self.section_type = [{
-                                    "iao_name": 'document part',      
-                                    "iao_id": 'IAO:0000314'
-                                }]
+            self.section_type = [{"iao_name": "document part", "iao_id": "IAO:0000314"}]
         else:
             self.section_type = mapping_result
 


### PR DESCRIPTION
# Description

I have changed the code for the main HTML conversion and the current XML script for IAO allocation to passages without a default value, making the infons dictionary incomplete. As decided previously, these passages are now classified as 'document part'. I ran the XML code locally, and there was no error.  

Fixes #116

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)
