### PR TITLE
Remove unused ruff ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,6 @@ select = [
 ]
 ignore = [
     "E501",   # line too long
-    "RUF001", # ambiguous multiplication sign
-    "RUF003", # ambiguous fullwidth colon
+    "RUF001", # ambiguous multiplication/minus/en dash sign
 ]
 pydocstyle.convention = "google"


### PR DESCRIPTION
# Description

I noticed that ignoring this check is no longer needed. So I thought I'd remove the ignore.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
