### PR TITLE
Converted BioCDocument class to a function

### DIFF
--- a/autocorpus/bioc_documents.py
+++ b/autocorpus/bioc_documents.py
@@ -6,7 +6,7 @@ from typing import Any
 from .bioc_passages import BioCPassage
 
 
-def get_formatted_bioc_document(data_store: "Autocorpus") -> dict[str, Any]:
+def get_formatted_bioc_document(data_store) -> dict[str, Any]:
     """Constructs the BioC document template using the provided data store.
 
     Args:

--- a/autocorpus/bioc_documents.py
+++ b/autocorpus/bioc_documents.py
@@ -1,70 +1,43 @@
 """Script for handling construction of BioC documents."""
 
 from pathlib import Path
+from typing import Any
 
 from .bioc_passages import BioCPassage
 
 
-class BiocDocument:
-    """BioC Document builder."""
+def get_formatted_bioc_document(data_store: "Autocorpus") -> dict[str, Any]:
+    """Constructs the BioC document template using the provided data store.
 
-    def build_passages(self, data_store):
-        """Constructs the BioC document passages using the provided data store.
+    Args:
+        data_store (Autocorpus): Input article data store.
 
-        Args:
-            data_store ([dict]): Article data store.
+    Returns:
+        (dict): BioC document complete populated with passages.
+    """
+    # build document passages
+    seen_headings = []
+    passages = [BioCPassage.from_title(data_store.main_text["title"], 0).as_dict()]
+    offset = 0  # offset for passage start position
+    if data_store.main_text["title"] not in seen_headings:
+        offset = len(data_store.main_text["title"])
+        seen_headings.append(data_store.main_text["title"])
+    for passage in data_store.main_text["paragraphs"]:
+        passage_obj = BioCPassage(passage, offset)
+        passages.append(passage_obj.as_dict())
+        offset += len(passage["body"])
+        if passage["subsection_heading"] not in seen_headings:
+            offset += len(passage["subsection_heading"])
+            seen_headings.append(passage["subsection_heading"])
+        if passage["section_heading"] not in seen_headings:
+            offset += len(passage["section_heading"])
+            seen_headings.append(passage["section_heading"])
 
-        Returns:
-            (list): list of BioC passages
-        """
-        seen_headings = []
-        passages = [BioCPassage.from_title(data_store.main_text["title"], 0).as_dict()]
-        if data_store.main_text["title"] not in seen_headings:
-            offset = len(data_store.main_text["title"])
-            seen_headings.append(data_store.main_text["title"])
-        for passage in data_store.main_text["paragraphs"]:
-            passage_obj = BioCPassage(passage, offset)
-            passages.append(passage_obj.as_dict())
-            offset += len(passage["body"])
-            if passage["subsection_heading"] not in seen_headings:
-                offset += len(passage["subsection_heading"])
-                seen_headings.append(passage["subsection_heading"])
-            if passage["section_heading"] not in seen_headings:
-                offset += len(passage["section_heading"])
-                seen_headings.append(passage["section_heading"])
-        return passages
-
-    def build_template(self, data_store):
-        """Constructs the BioC document template using the provided data store.
-
-        Args:
-            data_store ([dict]): Input article data store (list of dicts).
-
-        Returns:
-            (dict): BioC document complete populated with passages.
-        """
-        return {
-            "id": Path(data_store.file_path).name.split(".")[0],
-            "inputfile": data_store.file_path,
-            "infons": {},
-            "passages": self.build_passages(data_store),
-            "annotations": [],
-            "relations": [],
-        }
-
-    def __init__(self, input):
-        """BioC Document constructor using input dictionary.
-
-        Args:
-            input (dict): article document-level data.
-        """
-        self.document = self.build_template(input)
-        pass
-
-    def as_dict(self):
-        """Return the BioC document as a dictionary.
-
-        Returns:
-            (dict): BioC document as a dictionary
-        """
-        return self.document
+    return {
+        "id": Path(data_store.file_path).name.split(".")[0],
+        "inputfile": data_store.file_path,
+        "infons": {},
+        "passages": passages,
+        "annotations": [],
+        "relations": [],
+    }

--- a/autocorpus/bioc_formatter.py
+++ b/autocorpus/bioc_formatter.py
@@ -3,7 +3,7 @@
 import json
 from datetime import datetime
 
-from .bioc_documents import BiocDocument
+from .bioc_documents import get_formatted_bioc_document
 
 
 class BiocFormatter:
@@ -23,7 +23,7 @@ class BiocFormatter:
             "date": f"{datetime.today().strftime('%Y%m%d')}",
             "key": "autocorpus_fulltext.key",
             "infons": {},
-            "documents": [BiocDocument(input_vals).as_dict()],
+            "documents": [get_formatted_bioc_document(input_vals)],
         }
 
     def __init__(self, input_vals):


### PR DESCRIPTION
# Description

Converted the BioCDocument class to a function. Something to note here is that I've had to use the string literal 'Autocorpus' for the type hint, as importing the Autocorpus class currently results in a circular import. A lot of conversions going on, so I imagine the file structure will change soon too.

Fixes #179 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
