### PR TITLE
Convert `Section` class to functions

### DIFF
--- a/autocorpus/autocorpus.py
+++ b/autocorpus/autocorpus.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 from . import logger
 from .abbreviation import Abbreviations
 from .bioc_formatter import get_formatted_bioc_collection
-from .section import Section
+from .section import get_section
 from .table import get_table_json
 from .utils import handle_not_tables
 
@@ -99,7 +99,7 @@ class Autocorpus:
             maintext.append(keywords)
         sections = self.__get_sections(soup, config)
         for sec in sections:
-            maintext.extend(Section(config, sec).to_list())
+            maintext.extend(get_section(config, sec))
 
         # filter out the sections which do not contain any info
         filtered_text = [x for x in maintext if x]

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -137,7 +137,7 @@ class Paragraph:
     body: str
     section_type: str
 
-    dict = asdict
+    as_dict = asdict
 
 
 class Section:
@@ -147,7 +147,7 @@ class Section:
         self.paragraphs.append(
             Paragraph(
                 self.section_heading, self.subheader, body, self.section_type
-            ).dict()
+            ).as_dict()
         )
 
     def __navigate_children(self, soup_section, all_sub_sections, filtered_paragraphs):

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -137,7 +137,7 @@ class Paragraph:
     section_heading: str
     subsection_heading: str
     body: str
-    section_type: str
+    section_type: list[dict[str, str]]
 
     as_dict = asdict
 

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -13,6 +13,7 @@ from importlib import resources
 from typing import Any
 
 import nltk
+from bs4 import BeautifulSoup
 from fuzzywuzzy import fuzz
 
 from . import logger
@@ -140,6 +141,22 @@ class Paragraph:
     as_dict = asdict
 
 
+def _get_abbreviations(
+    abbreviations_config: dict[str, Any], soup_section: BeautifulSoup
+) -> str:
+    try:
+        abbreviations_tables = handle_not_tables(abbreviations_config, soup_section)
+        node = abbreviations_tables[0]["node"]
+        abbreviations = {}
+        for tr in node.find_all("tr"):
+            short_form, long_form = (td.get_text() for td in tr.find_all("td"))
+            abbreviations[short_form] = long_form
+    except Exception:
+        abbreviations = {}
+
+    return str(abbreviations)
+
+
 class Section:
     """Class for processing section data."""
 
@@ -175,22 +192,6 @@ class Section:
             children = []
         for child in children:
             self.__navigate_children(child, all_sub_sections, filtered_paragraphs)
-
-    def __get_abbreviations(self, soup_section):
-        if "abbreviations-table" in self.config:
-            try:
-                abbreviations_tables = handle_not_tables(
-                    self.config["abbreviations-table"], soup_section
-                )
-                abbreviations_tables = abbreviations_tables[0]["node"]
-                abbreviations = {}
-                for tr in abbreviations_tables.find_all("tr"):
-                    short_form, long_form = (td.get_text() for td in tr.find_all("td"))
-                    abbreviations[short_form] = long_form
-            except Exception:
-                abbreviations = {}
-
-            return str(abbreviations)
 
     def __get_section(self, soup_section):
         all_sub_sections = handle_not_tables(self.config["sub-sections"], soup_section)
@@ -245,9 +246,13 @@ class Section:
 
         # Different processing for abbreviations and references section types
         if self.section_heading == "Abbreviations":
-            abbreviations = self.__get_abbreviations(section_dict["node"])
-            self.__add_paragraph(abbreviations)
-            return
+            if abbreviations_config := config.get("abbreviations-table", None):
+                abbreviations = _get_abbreviations(
+                    abbreviations_config, section_dict["node"]
+                )
+                self.__add_paragraph(abbreviations)
+                return
+
         if {
             "iao_name": "references section",
             "iao_id": "IAO:0000320",

--- a/autocorpus/section.py
+++ b/autocorpus/section.py
@@ -242,7 +242,7 @@ class Section:
         self.section_heading = section_dict.get("headers", [""])[0]
         self.section_type = get_iao_term_mapping(self.section_heading)
         self.subheader = ""
-        self.paragraphs: list[dict[str, str]] = []
+        self.paragraphs: list[dict[str, Any]] = []
 
         # Different processing for abbreviations and references section types
         if self.section_heading == "Abbreviations":

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -3,9 +3,10 @@
 import re
 import unicodedata
 from pathlib import Path
+from typing import Any
 
 import bs4
-from bs4 import NavigableString
+from bs4 import BeautifulSoup, NavigableString
 from lxml import etree
 from lxml.html.soupparser import fromstring
 
@@ -199,15 +200,17 @@ def handle_defined_by(config, soup):
     return matches
 
 
-def handle_not_tables(config, soup):
+def handle_not_tables(
+    config: dict[str, Any], soup: BeautifulSoup
+) -> list[dict[str, NavigableString]]:
     """Executes a search on non-table bs4 soup objects based on provided config rules.
 
     Args:
-        config (dict): Parsed config rules to be used
-        soup (bs4.BeautifulSoup): BeautifulSoup object containing the input text to search
+        config: Parsed config rules to be used
+        soup: BeautifulSoup object containing the input text to search
 
     Returns:
-        (list): Matches for the provided config rules
+        Matches for the provided config rules
     """
     responses = []
     matches = handle_defined_by(config, soup)
@@ -215,7 +218,7 @@ def handle_not_tables(config, soup):
         for match in matches:
             response_addition = {"node": match}
             for ele in config["data"]:
-                seen_text = set()
+                seen_text = set()  # type: ignore
                 for definition in config["data"][ele]:
                     bs_attrs = parse_configs(definition)
                     new_matches = match.find_all(
@@ -225,7 +228,7 @@ def handle_not_tables(config, soup):
                     if new_matches:
                         response_addition[ele] = []
                     for newMatch in new_matches:
-                        if newMatch.get_text() in seen_text:
+                        if newMatch.get_text() in seen_text:  # This can never happen?
                             continue
                         else:
                             response_addition[ele].append(newMatch.get_text())

--- a/autocorpus/utils.py
+++ b/autocorpus/utils.py
@@ -202,7 +202,7 @@ def handle_defined_by(config, soup):
 
 def handle_not_tables(
     config: dict[str, Any], soup: BeautifulSoup
-) -> list[dict[str, NavigableString]]:
+) -> list[dict[str, Any]]:
     """Executes a search on non-table bs4 soup objects based on provided config rules.
 
     Args:


### PR DESCRIPTION
# Description

This PR converts the big `Section` class into separate functions (with a few dataclasses used for return types). @AdrianDAlessandro started this work before he went on leave and I finished it up.

I've tried to not inadvertently change the behaviour of the code, but there are a couple of things that I think could be problems with the existing code:

1. @AdrianDAlessandro spotted that there is a `seen_text` variable in `handle_not_tables` that is never actually added to. Presumably it's supposed to be used to filter out duplicates, but it isn't currently doing anything.
2. If no subheading is found for a given paragraph, the code uses whatever subheading it last came across, which doesn't seem quite right (e.g. if it last encountered a subsubheading in a nested section, do you really want to use that for the next higher-level section?). I'm less sure this one is a problem, but just wanted to double-check.

On the subject of `handle_not_tables`, it seems that every/almost every caller of that function immediately processes the results like this:

```py
result = [x["node"] for x in result]
```

Should we just do this processing in the function itself?

Closes #183.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
