### PR TITLE
Various fixes for documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,16 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Poetry
-        uses: abatilo/actions-poetry@v4.0.0
+      - uses: ./.github/actions/setup
         with:
-          poetry-version: 1.8.3
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          cache: poetry
-      - name: Install dependencies
-        run: poetry install
+          python-version: '3.13'
       - name: Build docs with MkDocs
         run: poetry run mkdocs build
       - name: Setup Pages

--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@
 
 *Requires Python 3.10+* <!-- markdownlint-disable-line MD036 -->
 
-The Automated pipeline for Consistent Outputs from Research Publications (Auto-CORPus) is a tool for the standardisation and conversion of publication HTML to three convenient machine-interpretable outputs to support biomedical text analytics. Firstly, Auto-CORPus can be configured to convert HTML from various publication sources to [BioC format](http://bioc.sourceforge.net/). Secondly, Auto-CORPus transforms publication tables to a JSON format to store, exchange and annotate table data between text analytics systems. Finally, Auto-CORPus extracts abbreviations declared within publication text and provides an abbreviations JSON output that relates an abbreviation with the full definition.
+The Automated pipeline for Consistent Outputs from Research Publications (Auto-CORPus) is a tool for the standardisation and conversion of publication HTML to three convenient machine-interpretable outputs to support biomedical text analytics. Firstly, Auto-CORPus can be configured to convert HTML from various publication sources to [BioC format]. Secondly, Auto-CORPus transforms publication tables to a JSON format to store, exchange and annotate table data between text analytics systems. Finally, Auto-CORPus extracts abbreviations declared within publication text and provides an abbreviations JSON output that relates an abbreviation with the full definition.
 
-We present a JSON format for sharing table content and metadata that is based on the BioC format. The [JSON schema](keyFiles/table_schema.json) for the tables JSON can be found within the [keyfiles](keyFiles) directory.
+We present a JSON format for sharing table content and metadata that is based on the BioC format. The [JSON schema] for the tables JSON can be found within the [keyFiles] directory.
 
-The documentation for Auto-CORPus is available on our [GitHub Pages site](https://omicsnlp.github.io/Auto-CORPus/).
+The documentation for Auto-CORPus is available on our [GitHub Pages site].
+
+[BioC format]: http://bioc.sourceforge.net/
+[JSON schema]: https://github.com/omicsNLP/Auto-CORPus/blob/main/keyFiles/table_schema.json
+[keyFiles]: https://github.com/omicsNLP/Auto-CORPus/tree/main/keyFiles
+[GitHub Pages site]: https://omicsnlp.github.io/Auto-CORPus/
 
 ## Installation
 
@@ -47,9 +52,9 @@ auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/dire
 
 ## Config files
 
-If you wish to contribute or edit a config file then please follow the instructions in the [config guide](docs/config_tutorial.md).
+If you wish to contribute or edit a config file then please follow the instructions in the [config guide].
 
-Auto-CORPus is able to parse HTML from different publishers, which utilise different HTML structures and naming conventions. This is made possible by the inclusion of config files which tell Auto-CORPus how to identify specific sections of the article/table within the source HTML. We have supplied a config template along with example config files for [PubMed Central](autocorpus/configs/config_pmc.json), [Plos Genetics](autocorpus/configs/config_plos_genetics.json) and [Nature Genetics](autocorpus/configs/config_nature_genetics.json) in the [configs](autocorpus/configs) directory. Users of Auto-CORPus can submit their own config files for different sources via the [issues](https://github.com/omicsNLP/Auto-CORPus/issues) tab.
+Auto-CORPus is able to parse HTML from different publishers, which utilise different HTML structures and naming conventions. This is made possible by the inclusion of config files which tell Auto-CORPus how to identify specific sections of the article/table within the source HTML. We have supplied a config template along with example config files for [PubMed Central], [PLOS Genetics] and [Nature Genetics] in the [configs] directory. Users of Auto-CORPus can submit their own config files for different sources via the [issues] tab.
 
 **Auto-CORPus recognises 2 types of input file which are:**
 
@@ -94,6 +99,13 @@ PMC1_tables.json (contains table 1 & 2 and any tables described within the main 
 
 A log file is produced in the output directory providing details of the day/time Auto-CORPus was run,
 the arguments used and information about which files were successfully/unsuccessfully processed with a relevant error message.
+
+[config guide]: https://omicsnlp.github.io/Auto-CORPus/config_tutorial/
+[PubMed Central]: https://github.com/omicsNLP/Auto-CORPus/blob/main/autocorpus/configs/config_pmc.json
+[PLOS Genetics]: https://github.com/omicsNLP/Auto-CORPus/blob/main/autocorpus/configs/config_plos_genetics.json
+[Nature Genetics]: https://github.com/omicsNLP/Auto-CORPus/blob/main/autocorpus/configs/config_nature_genetics.json
+[configs]: https://github.com/omicsNLP/Auto-CORPus/tree/main/autocorpus/configs
+[issues]: https://github.com/omicsNLP/Auto-CORPus/issues
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Automated pipeline for Consistent Outputs from Research Publications (Auto-C
 
 We present a JSON format for sharing table content and metadata that is based on the BioC format. The [JSON schema](keyFiles/table_schema.json) for the tables JSON can be found within the [keyfiles](keyFiles) directory.
 
+The documentation for Auto-CORPus is available on our [GitHub Pages site](https://omicsnlp.github.io/Auto-CORPus/).
+
 ## Installation
 
 Install with pip

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ Auto-CORPus is able to parse HTML from different publishers, which utilise diffe
 - Full text HTML documents covering the entire article
 - HTML files which describe a single table
 
-Current work in progress is extending this to include images of tables. See the [Alpha Testing](#alpha-testing) section below.
-
 Auto-CORPus does not provide functionality to retrieve input files directly from the publisher. Input file retrieval must be completed by the user in a way which the publisher permits.
 
 Auto-CORPus relies on a standard naming convention to recognise the files and identify the correct order of tables. The naming convention can be seen below:
@@ -139,26 +137,3 @@ To get started:
    ```
 
 **Note:** The `auto-corpus` commandline script is also available and will behave the same as `python -m autocorpus`
-
-## Alpha testing
-
-We are developing an Auto-CORPus plugin to process images of tables and we include an alpha version of this
-functionality. Table image files can be processed in either .png or .jpeg/jpg formats. We are working on improving the accuracy of both the table layout and character recognition aspects, and we will update this repo as the plugin advances.
-
-We utilise [opencv](https://pypi.org/project/opencv-python/) for cell detection and [tesseract](https://github.com/tesseract-ocr/tesseract) for optical character recognition. Tesseract will need to be installed separately onto your system for the table image recognition aspect of Auto-CORPus to work. Please follow the guidance given by tesseract on how to do this.
-
-We have made trained datasets available for use with this feature, but we will continue to train these datasets to
-increase their accuracy, and it is very likely that the trained datasets we offer will be updated frequently during
-active development periods.
-
-As with HTML input files, the image input files should be retrieved by the user in a way which the publisher permits. The naming convention is:
-
-Table image file: {any_name_you_want}_table_X.png/jpg/jpeg
-
-- {any_name_you_want} must be identical to the name given to the full text file followed by_table_X where X is the table number
-
-### Additional argument
-
-| Flag | Name | Description |
-| -------- | ------- | ------- |
-| `-s` | Trained Dataset | Trained dataset to use for pytesseract OCR. Value should be given in a format recognised by pytesseract with a "+" between each datafile, such as "eng+all" |

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ To get started:
 1. Run the main app for a single file example:
 
    ```sh
-   python -m autocorpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/html/file" -o JSON
+   auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/html/file" -o JSON
    ```
 
 1. Run the main app for a directory of files example
 
    ```sh
-   python -m autocorpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/directory/of/html/files" -o JSON
+   auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/directory/of/html/files" -o JSON
    ```

--- a/README.md
+++ b/README.md
@@ -135,5 +135,3 @@ To get started:
    ```sh
    python -m autocorpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/directory/of/html/files" -o JSON
    ```
-
-**Note:** The `auto-corpus` commandline script is also available and will behave the same as `python -m autocorpus`

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Auto-CORPus will first group files based on common elements in their file name {
 
 **Input:**
 
-```sh
+```txt
 PMC1.html
 PMC1_table_1.html
 PMC1_table_2.html
@@ -89,7 +89,7 @@ PMC1_table_2.html
 
 **Output:**
 
-```sh
+```txt
 PMC1_bioc.json
 PMC1_abbreviations.json
 PMC1_tables.json (contains table 1 & 2 and any tables described within the main text)

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/dire
 
 ### Available arguments
 
-| Flag | Name | Description |
-| -------- | ------- | ------- |
-| `-f` | Input File Path | File or directory to run Auto-CORPus on |
+| Flag | Name             | Description                                               |
+|------|------------------|-----------------------------------------------------------|
+| `-f` | Input File Path  | File or directory to run Auto-CORPus on                   |
 | `-t` | Output File Path | Directory path where Auto-CORPus should save output files |
-| `-c` | Config | Which config file to use |
-| `-o` | Output Format | Either `JSON` or `XML` (defaults to `JSON`) |
+| `-c` | Config           | Which config file to use                                  |
+| `-o` | Output Format    | Either `JSON` or `XML` (defaults to `JSON`)               |
 
 ## Config files
 

--- a/docs/config_tutorial.md
+++ b/docs/config_tutorial.md
@@ -2,7 +2,7 @@
 
 For instructions on how to submit your own configs or make changes to existing config files please see [submit/update](#submitting-and-editing-config-files)
 
-*The [config_pmc.json](https://github.com/omicsNLP/Auto-CORPus/blob/main/configs/config_pmc.json) file is used as the example in this tutorial.*
+*The [config_pmc.json](https://github.com/omicsNLP/Auto-CORPus/blob/main/autocorpus/configs/config_pmc.json) file is used as the example in this tutorial.*
 
 There are no required sections within the config file, if you do not define a section then Auto-CORPus will not try to process it.
 Auto-CORPus will also not try to process any sections defined within the configs which are not within our template config file,

--- a/docs/gen_ref_nav.py
+++ b/docs/gen_ref_nav.py
@@ -4,36 +4,29 @@ from pathlib import Path
 
 import mkdocs_gen_files
 
+nav = mkdocs_gen_files.Nav()
 
-def main():
-    """Generate references."""
-    nav = mkdocs_gen_files.Nav()
+for path in sorted(Path("autocorpus").glob("**/*.py")):
+    module_path = path.relative_to(".").with_suffix("")
+    doc_path = path.relative_to(".").with_suffix(".md")
+    full_doc_path = Path("reference", doc_path)
 
-    for path in sorted(Path("autocorpus").glob("**/*.py")):
-        module_path = path.relative_to(".").with_suffix("")
-        doc_path = path.relative_to(".").with_suffix(".md")
-        full_doc_path = Path("reference", doc_path)
+    parts = list(module_path.parts)
+    if ".array_cache" in parts:
+        continue
+    elif parts[-1] == "__init__":
+        parts = parts[:-1]
+        doc_path = doc_path.with_name("index.md")
+        full_doc_path = full_doc_path.with_name("index.md")
+    elif parts[-1] == "__main__":
+        continue
+    nav[parts] = doc_path
 
-        parts = list(module_path.parts)
-        if ".array_cache" in parts:
-            continue
-        elif parts[-1] == "__init__":
-            parts = parts[:-1]
-            doc_path = doc_path.with_name("index.md")
-            full_doc_path = full_doc_path.with_name("index.md")
-        elif parts[-1] == "__main__":
-            continue
-        nav[parts] = doc_path
+    with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+        ident = ".".join(parts)
+        print("::: " + ident, file=fd)
 
-        with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-            ident = ".".join(parts)
-            print("::: " + ident, file=fd)
+    mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
 
-        mkdocs_gen_files.set_edit_path(full_doc_path, Path("../") / path)
-
-    with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
-        nav_file.writelines(nav.build_literate_nav())
-
-
-if __name__ == "__main__":
-    main()
+with mkdocs_gen_files.open("reference/SUMMARY.md", "w") as nav_file:
+    nav_file.writelines(nav.build_literate_nav())

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,1 +1,2 @@
---8<-- "README.md" <!-- markdownlint-disable-line MD041 -->
+<!-- markdownlint-disable-next-line MD041 -->
+--8<-- "README.md"


### PR DESCRIPTION
# Description

In the course of working on something else I noticed the API documentation isn't being generated anymore (I broke it with commit c126e51d388926da494240a46ddf1c3982c7eee5).

I also fixed up some other documentation-related things while I was at it, namely:

- Add a link to the documentation to the readme so people can find it
- Fix a syntax error in `index.md` that meant `README.md` wasn't properly included
- Remove the use of the `actions-poetry` GitHub Action (it's a bit temperamental and we've already removed it from the other workflows)

Closes #126.

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
