### PR TITLE
Convert `Abbreviations` class to functions

### DIFF
--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -338,8 +338,8 @@ class Abbreviations:
     def __get_abbre_plain_text(self, soup_og):
         abbre_text = soup_og.get_text()
         abbre_list = abbre_text.split(";")
-        list_lenth = len(abbre_list)
-        return abbre_list, list_lenth
+        list_length = len(abbre_list)
+        return abbre_list, list_length
 
     def __get_abbre_dict_given_by_author(self, soup_og):
         header = soup_og.find_all("h2", recursive=True)
@@ -362,10 +362,10 @@ class Abbreviations:
 
                     # when abbre is plain text
                     elif tag_name == "p":
-                        abbre_list, list_lenth = self.__get_abbre_plain_text(
+                        abbre_list, list_length = self.__get_abbre_plain_text(
                             nearest_down_tag
                         )
-                        if list_lenth <= 2:
+                        if list_length <= 2:
                             nearest_down_tag = nearest_down_tag.next_element
                             continue
                         else:

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -371,7 +371,7 @@ def _get_abbre_dict_given_by_author(soup: BeautifulSoup) -> dict[str, str]:
 class Abbreviations:
     """Class for processing abbreviations using Auto-CORPus configurations."""
 
-    def __get_abbreviations(self, main_text, soup, config):
+    def __get_abbreviations(self, main_text, soup):
         paragraphs = main_text["paragraphs"]
         all_abbreviations = {}
         for paragraph in paragraphs:
@@ -382,18 +382,16 @@ class Abbreviations:
 
         abbrev_json = {}
 
-        for key in author_provided_abbreviations.keys():
-            abbrev_json[key] = {
-                author_provided_abbreviations[key]: ["abbreviations section"]
-            }
-        for key in all_abbreviations:
-            if key in abbrev_json:
-                if all_abbreviations[key] in abbrev_json[key].keys():
-                    abbrev_json[key][all_abbreviations[key]].append("fulltext")
-                else:
-                    abbrev_json[key][all_abbreviations[key]] = ["fulltext"]
-            else:
-                abbrev_json[key] = {all_abbreviations[key]: ["fulltext"]}
+        for k, v in author_provided_abbreviations.items():
+            abbrev_json[k] = {v: ["abbreviations section"]}
+
+        for k, v in all_abbreviations.items():
+            if k not in abbrev_json:
+                abbrev_json[k] = {}
+            if v not in abbrev_json[k]:
+                abbrev_json[k][v] = []
+
+            abbrev_json[k][v].append("fulltext")
 
         return abbrev_json
 
@@ -423,17 +421,16 @@ class Abbreviations:
             passages.append(short_template)
         return template
 
-    def __init__(self, main_text, soup, config, file_path):
+    def __init__(self, main_text, soup, file_path):
         """Extract abbreviations from the input main text, using the provided soup and config objects.
 
         Args:
             main_text (str): Article main text data
             soup (bs4.BeautifulSoup): Article as a BeautifulSoup object
-            config (dict): AC configuration rules
             file_path (str): Input file path
         """
         self.abbreviations = self.__biocify_abbreviations(
-            self.__get_abbreviations(main_text, soup, config), file_path
+            self.__get_abbreviations(main_text, soup), file_path
         )
 
     def to_dict(self):

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -221,9 +221,7 @@ class Abbreviations:
                 else:
                     l_index -= 1
 
-        new_candidate = Candidate(definition[l_index : len(definition)])
-        new_candidate.set_position(definition.start, definition.stop)
-        definition = new_candidate
+        definition = definition[l_index:]
 
         tokens = len(definition.split())
         length = len(abbrev)

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -1,7 +1,6 @@
 """Handles the processing of abbreviations.
 
 modules used:
-- logging: log errors/status messages
 - collections: used for counting the most common occurrences
 - datetime: datetime stamping
 - pathlib: OS-agnostic pathing

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -135,44 +135,43 @@ class Abbreviations:
         definition_freq = first_chars.count(key)
         candidate_freq = candidate.lower().count(key)
 
-        # Look for the list of tokens in front of candidate that
-        # have a sufficient number of tokens starting with key
-        if candidate_freq <= definition_freq:
-            # we should at least have a good number of starts
-            count = 0
-            start = 0
-            start_index = len(first_chars) - 1
-            while count < candidate_freq:
-                if abs(start) > len(first_chars):
-                    raise ValueError(f"candidate {candidate} not found")
-                start -= 1
-                # Look up key in the definition
-                try:
-                    start_index = first_chars.index(key, len(first_chars) + start)
-                except ValueError:
-                    pass
-
-                # Count the number of keys in definition
-                count = first_chars[start_index:].count(key)
-
-            # We found enough keys in the definition so return the definition as a definition candidate
-            start = len(" ".join(tokens[:start_index]))
-            stop = candidate.start - 1
-            candidate = sentence[start:stop]
-
-            # Remove whitespace
-            start = start + len(candidate) - len(candidate.lstrip())
-            stop = stop - len(candidate) + len(candidate.rstrip())
-            candidate = sentence[start:stop]
-
-            new_candidate = Candidate(candidate)
-            new_candidate.set_position(start, stop)
-            return new_candidate
-
-        else:
+        if candidate_freq > definition_freq:
             raise ValueError(
                 "There are less keys in the tokens in front of candidate than there are in the candidate"
             )
+
+        # Look for the list of tokens in front of candidate that
+        # have a sufficient number of tokens starting with key
+        # we should at least have a good number of starts
+        count = 0
+        start = 0
+        start_index = len(first_chars) - 1
+        while count < candidate_freq:
+            if abs(start) > len(first_chars):
+                raise ValueError(f"candidate {candidate} not found")
+            start -= 1
+            # Look up key in the definition
+            try:
+                start_index = first_chars.index(key, len(first_chars) + start)
+            except ValueError:
+                pass
+
+            # Count the number of keys in definition
+            count = first_chars[start_index:].count(key)
+
+        # We found enough keys in the definition so return the definition as a definition candidate
+        start = len(" ".join(tokens[:start_index]))
+        stop = candidate.start - 1
+        candidate = sentence[start:stop]
+
+        # Remove whitespace
+        start = start + len(candidate) - len(candidate.lstrip())
+        stop = stop - len(candidate) + len(candidate.rstrip())
+        candidate = sentence[start:stop]
+
+        new_candidate = Candidate(candidate)
+        new_candidate.set_position(start, stop)
+        return new_candidate
 
     def __select_definition(self, definition, abbrev):
         """Takes a definition candidate and an abbreviation candidate and returns True if the chars in the abbreviation occur in the definition.

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -286,6 +286,7 @@ def _extract_abbreviation_definition_pairs(
                 abbrev_map[abbrev].append(definition)
         except (ValueError, IndexError) as e:
             logger.debug(f"{i} Error processing sentence {sentence}: {e.args[0]}")
+            omit += 1
     logger.debug(f"{written} abbreviations detected and kept ({omit} omitted)")
 
     # Return the most common definition for each term

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -372,7 +372,7 @@ def _get_abbre_dict_given_by_author(soup: BeautifulSoup) -> dict[str, str]:
 _AbbreviationsDict = dict[str, dict[str, list[str]]]
 
 
-def _get_abbreviations(
+def _extract_abbreviations(
     main_text: dict[str, Any], soup: BeautifulSoup
 ) -> _AbbreviationsDict:
     paragraphs = main_text["paragraphs"]
@@ -424,24 +424,17 @@ def _biocify_abbreviations(
     }
 
 
-class Abbreviations:
-    """Class for processing abbreviations using Auto-CORPus configurations."""
+def get_abbreviations(
+    main_text: dict[str, Any], soup: BeautifulSoup, file_path: str
+) -> dict[str, Any]:
+    """Extract abbreviations from the input main text.
 
-    def __init__(self, main_text, soup, file_path):
-        """Extract abbreviations from the input main text, using the provided soup and config objects.
+    Args:
+        main_text: Article main text data
+        soup: Article as a BeautifulSoup object
+        file_path: Input file path
 
-        Args:
-            main_text (str): Article main text data
-            soup (bs4.BeautifulSoup): Article as a BeautifulSoup object
-            file_path (str): Input file path
-        """
-        self.abbreviations = _biocify_abbreviations(
-            _get_abbreviations(main_text, soup), file_path
-        )
-
-    def to_dict(self):
-        """Retrieves abbreviations BioC dict.
-
-        Returns (dict): abbreviations BioC dict.
-        """
-        return self.abbreviations
+    Returns:
+        Abbreviations in BioC format.
+    """
+    return _biocify_abbreviations(_extract_abbreviations(main_text, soup), file_path)

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -328,63 +328,52 @@ class Abbreviations:
 
     def __get_abbre_dict_given_by_author(self, soup_og):
         header = soup_og.find_all("h2", recursive=True)
-        abbre_dict = {}
         for element in header:
-            if re2.search("abbreviation", element.get_text(), re2.IGNORECASE):
-                nearest_down_tag = element.next_element
-                while nearest_down_tag:
-                    tag_name = nearest_down_tag.name
+            if not re2.search("abbreviation", element.get_text(), re2.IGNORECASE):
+                continue
 
+            nearest_down_tag = element.next_element
+            while nearest_down_tag:
+                tag_name = nearest_down_tag.name
+
+                match tag_name:
                     # when abbre is table
-                    if tag_name == "table":
-                        abbre_dict = _abbre_table_to_dict(nearest_down_tag)
-                        break
+                    case "table":
+                        return _abbre_table_to_dict(nearest_down_tag)
 
                     # when abbre is list
-                    elif tag_name == "dl":
-                        abbre_dict = _abbre_list_to_dict(nearest_down_tag)
-                        break
+                    case "dl":
+                        return _abbre_list_to_dict(nearest_down_tag)
 
                     # when abbre is plain text
-                    elif tag_name == "p":
+                    case "p":
                         abbre_list = _get_abbre_plain_text(nearest_down_tag)
                         if len(abbre_list) <= 2:
                             nearest_down_tag = nearest_down_tag.next_element
                             continue
-                        else:
-                            for abbre_pair in abbre_list:
-                                if len(abbre_pair.split(":")) == 2:
-                                    abbre_dict.update(
-                                        {
-                                            abbre_pair.split(":")[0]: abbre_pair.split(
-                                                ":"
-                                            )[1]
-                                        }
-                                    )
-                                elif len(abbre_pair.split(",")) == 2:
-                                    abbre_dict.update(
-                                        {
-                                            abbre_pair.split(",")[0]: abbre_pair.split(
-                                                ","
-                                            )[1]
-                                        }
-                                    )
-                                elif len(abbre_pair.split(" ")) == 2:
-                                    abbre_dict.update(
-                                        {
-                                            abbre_pair.split(" ")[0]: abbre_pair.split(
-                                                " "
-                                            )[1]
-                                        }
-                                    )
-                            break
+
+                        abbre_dict = {}
+                        for abbre_pair in abbre_list:
+                            if len(abbre_pair.split(":")) == 2:
+                                abbre_dict.update(
+                                    {abbre_pair.split(":")[0]: abbre_pair.split(":")[1]}
+                                )
+                            elif len(abbre_pair.split(",")) == 2:
+                                abbre_dict.update(
+                                    {abbre_pair.split(",")[0]: abbre_pair.split(",")[1]}
+                                )
+                            elif len(abbre_pair.split(" ")) == 2:
+                                abbre_dict.update(
+                                    {abbre_pair.split(" ")[0]: abbre_pair.split(" ")[1]}
+                                )
+                        return abbre_dict
 
                     # search until next h2
-                    elif tag_name == "h2":
+                    case "h2":
                         break
-                    else:
+                    case _:
                         nearest_down_tag = nearest_down_tag.next_element
-        return abbre_dict
+        return {}
 
     def __get_abbreviations(self, main_text, soup, config):
         paragraphs = main_text["paragraphs"]

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -193,11 +193,7 @@ class Abbreviations:
         l_index = -1
 
         while 1:
-            try:
-                long_char = definition[l_index].lower()
-            except IndexError:
-                raise
-
+            long_char = definition[l_index].lower()
             short_char = abbrev[s_index].lower()
 
             if not short_char.isalnum():

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -398,30 +398,28 @@ class Abbreviations:
     """Class for processing abbreviations using Auto-CORPus configurations."""
 
     def __biocify_abbreviations(self, abbreviations, file_path):
-        template = {
+        passages = []
+        for short, long in abbreviations.items():
+            counter = 1
+            short_template = {"text_short": short}
+            for definition, kinds in long.items():
+                short_template[f"text_long_{counter}"] = definition.replace("\n", " ")
+                short_template[f"extraction_algorithm_{counter}"] = ", ".join(kinds)
+                counter += 1
+            passages.append(short_template)
+
+        return {
             "source": "Auto-CORPus (abbreviations)",
-            "date": f"{datetime.today().strftime('%Y%m%d')}",
+            "date": datetime.today().strftime("%Y%m%d"),
             "key": "autocorpus_abbreviations.key",
             "documents": [
                 {
-                    "id": Path(file_path).name.split(".")[0],
+                    "id": Path(file_path).name.partition(".")[0],
                     "inputfile": file_path,
-                    "passages": [],
+                    "passages": passages,
                 }
             ],
         }
-        passages = template["documents"][0]["passages"]
-        for short in abbreviations.keys():
-            counter = 1
-            short_template = {"text_short": short}
-            for long in abbreviations[short].keys():
-                short_template[f"text_long_{counter}"] = long.replace("\n", " ")
-                short_template[f"extraction_algorithm_{counter}"] = ", ".join(
-                    abbreviations[short][long]
-                )
-                counter += 1
-            passages.append(short_template)
-        return template
 
     def __init__(self, main_text, soup, file_path):
         """Extract abbreviations from the input main text, using the provided soup and config objects.

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -354,18 +354,11 @@ class Abbreviations:
 
                         abbre_dict = {}
                         for abbre_pair in abbre_list:
-                            if len(abbre_pair.split(":")) == 2:
-                                abbre_dict.update(
-                                    {abbre_pair.split(":")[0]: abbre_pair.split(":")[1]}
-                                )
-                            elif len(abbre_pair.split(",")) == 2:
-                                abbre_dict.update(
-                                    {abbre_pair.split(",")[0]: abbre_pair.split(",")[1]}
-                                )
-                            elif len(abbre_pair.split(" ")) == 2:
-                                abbre_dict.update(
-                                    {abbre_pair.split(" ")[0]: abbre_pair.split(" ")[1]}
-                                )
+                            for sep in ":, ":
+                                if abbre_pair.count(sep) == 1:
+                                    k, _, v = abbre_pair.partition(sep)
+                                    abbre_dict[k] = v
+                                    break
                         return abbre_dict
 
                     # search until next h2

--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -321,9 +321,7 @@ class Abbreviations:
 
     def __get_abbre_plain_text(self, soup_og):
         abbre_text = soup_og.get_text()
-        abbre_list = abbre_text.split(";")
-        list_length = len(abbre_list)
-        return abbre_list, list_length
+        return abbre_text.split(";")
 
     def __get_abbre_dict_given_by_author(self, soup_og):
         header = soup_og.find_all("h2", recursive=True)
@@ -346,10 +344,8 @@ class Abbreviations:
 
                     # when abbre is plain text
                     elif tag_name == "p":
-                        abbre_list, list_length = self.__get_abbre_plain_text(
-                            nearest_down_tag
-                        )
-                        if list_length <= 2:
+                        abbre_list = self.__get_abbre_plain_text(nearest_down_tag)
+                        if len(abbre_list) <= 2:
                             nearest_down_tag = nearest_down_tag.next_element
                             continue
                         else:

--- a/autocorpus/autocorpus.py
+++ b/autocorpus/autocorpus.py
@@ -292,7 +292,7 @@ class Autocorpus:
             self.main_text = self.__extract_text(soup, self.config)
             try:
                 self.abbreviations = Abbreviations(
-                    self.main_text, soup, self.config, self.file_path
+                    self.main_text, soup, self.file_path
                 ).to_dict()
             except Exception as e:
                 logger.error(e)

--- a/autocorpus/autocorpus.py
+++ b/autocorpus/autocorpus.py
@@ -8,7 +8,7 @@ from bioc import biocjson, biocxml
 from bs4 import BeautifulSoup
 
 from . import logger
-from .abbreviation import Abbreviations
+from .abbreviation import get_abbreviations
 from .bioc_formatter import get_formatted_bioc_collection
 from .section import get_section
 from .table import get_table_json
@@ -291,9 +291,9 @@ class Autocorpus:
             self.__process_html_tables(self.file_path, soup, self.config)
             self.main_text = self.__extract_text(soup, self.config)
             try:
-                self.abbreviations = Abbreviations(
+                self.abbreviations = get_abbreviations(
                     self.main_text, soup, self.file_path
-                ).to_dict()
+                )
             except Exception as e:
                 logger.error(e)
         if self.linked_tables:


### PR DESCRIPTION
# Description

This PR breaks up the large `Abbreviations` class into separate functions. I've also done some general clean-up of the code along the way. The structure of the functions is mostly the same, though I did move some small bits around and got rid of the `Candidate` class as I think it was pretty confusing (it inherited from `str`, for one thing). 

Closes #178.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
