### PR TITLE
Reduce the code in the main module

### DIFF
--- a/autocorpus/inputs.py
+++ b/autocorpus/inputs.py
@@ -1,0 +1,118 @@
+"""Module for processing the structure of the autocorpus input files."""
+
+import re
+from pathlib import Path
+from typing import Any
+
+from . import logger
+
+
+def get_file_type(file_path: Path) -> str:
+    """Identify the type of files present in the given path.
+
+    Args:
+        file_path: file path to be checked
+
+    Returns:
+        "directory", "main_text" or "linked_table"
+    """
+    if file_path.is_dir():
+        return "directory"
+    if file_path.suffix == ".html":
+        if file_path.name.startswith("table_"):
+            return "linked_tables"
+        return "main_text"
+
+    logger.warning(
+        f"unable to identify file type for {file_path}, file will not be processed"
+    )
+    return ""
+
+
+def fill_structure(structure, key, ftype, fpath: Path):
+    """Update the structure dict to contain the correct structure.
+
+    Takes the structure dict, if key is not present then creates new entry with default
+    values. It then adds `fpath` to the correct `ftype`.
+
+    Args:
+        structure: structure dict
+        key: base file name
+        ftype: file type (main_text, linked_table)
+        fpath: full path to the file
+
+    Returns:
+        The updated structure dictionary
+    """
+    if key not in structure:
+        structure[key] = {
+            "main_text": "",
+            "out_dir": "",
+            "linked_tables": [],
+        }
+    if ftype == "main_text" or ftype == "out_dir":
+        structure[key][ftype] = str(fpath)
+    else:
+        structure[key][ftype].append(str(fpath))
+    return structure
+
+
+def read_file_structure(file_path: Path, target_dir: Path) -> dict[str, Any]:
+    """Takes in any file structure (flat or nested) and groups files.
+
+    Returns a dict of files which are all related and the paths to each related file.
+
+    Args:
+        file_path: path to the file or directory
+        target_dir: path to the target directory
+
+    Returns:
+        Dictionary of files which are all related and the paths to each related file
+    """
+    if file_path.is_dir():
+        structure: dict[str, Any] = {}
+        all_fpaths = file_path.rglob("*")
+        for fpath in all_fpaths:
+            tmp_out = fpath.relative_to(file_path).parent
+            out_dir = target_dir / tmp_out
+            ftype = get_file_type(fpath)
+            base_file = ""
+            if ftype == "directory":
+                continue
+            elif ftype == "main_text":
+                base_file = re.sub(r"\.html", "", str(fpath))
+                structure = fill_structure(structure, base_file, "main_text", fpath)
+                structure = fill_structure(structure, base_file, "out_dir", out_dir)
+            elif ftype == "linked_tables":
+                base_file = re.sub(r"_table_\d+\.html", "", str(fpath))
+                structure = fill_structure(structure, base_file, "linked_tables", fpath)
+                structure = fill_structure(structure, base_file, "out_dir", out_dir)
+            elif not ftype:
+                logger.warning(
+                    f"cannot determine file type for {fpath}. "
+                    "AC will not process this file"
+                )
+            if base_file in structure:
+                structure = fill_structure(structure, base_file, "out_dir", out_dir)
+        return structure
+
+    ftype = get_file_type(file_path)
+    if ftype == "main_text":
+        base_file = re.sub(r"\.html", "", str(file_path)).split("/")[-1]
+    if ftype == "linked_tables":
+        base_file = re.sub(r"_table_\d+\.html", "", str(file_path)).split("/")[-1]
+    if not ftype:
+        raise OSError(
+            f"cannot determine file type for {file_path}. AC will not process this file"
+        )
+    template = {
+        base_file: {
+            "main_text": "",
+            "out_dir": str(target_dir),
+            "linked_tables": [],
+        }
+    }
+    template[base_file][get_file_type(file_path)] = str(
+        file_path if get_file_type(file_path) == "main_text" else [file_path]
+    )
+    return template

--- a/autocorpus/run.py
+++ b/autocorpus/run.py
@@ -1,0 +1,54 @@
+"""Module to run the autocorpus pipeline."""
+
+from pathlib import Path
+
+from .autocorpus import Autocorpus
+
+
+def run_autocorpus(config, structure, key, output_format):
+    """Run the autocorpus pipeline on a given file.
+
+    Args:
+        config: The configuration file to use.
+        structure: The structure of the input files.
+        key: The key in the structure dict for the current file.
+        output_format: The output format to use (JSON or XML).
+    """
+    ac = Autocorpus(
+        config=config,
+        main_text=structure[key]["main_text"],
+        linked_tables=sorted(structure[key]["linked_tables"]),
+    )
+
+    ac.process_files()
+
+    out_dir = Path(structure[key]["out_dir"])
+    if structure[key]["main_text"]:
+        key = key.replace("\\", "/")
+        if output_format.lower() == "json":
+            with open(
+                out_dir / f"{Path(key).name}_bioc.json",
+                "w",
+                encoding="utf-8",
+            ) as outfp:
+                outfp.write(ac.main_text_to_bioc_json())
+        else:
+            with open(
+                out_dir / f"{Path(key).name}_bioc.xml",
+                "w",
+                encoding="utf-8",
+            ) as outfp:
+                outfp.write(ac.main_text_to_bioc_xml())
+        with open(
+            out_dir / f"{Path(key).name}_abbreviations.json",
+            "w",
+            encoding="utf-8",
+        ) as outfp:
+            outfp.write(ac.abbreviations_to_bioc_json())
+
+    # AC does not support the conversion of tables or abbreviations to XML
+    if ac.has_tables:
+        with open(
+            out_dir / f"{Path(key).name}_tables.json", "w", encoding="utf-8"
+        ) as outfp:
+            outfp.write(ac.tables_to_bioc_json())


### PR DESCRIPTION
# Description

This PR reduces the code in `main.py` by moving some of it into two separate modules. One for inputs and one for running the program. It could be further reduced, however there are other issues that can be completed to address that in future. This is because the part that can be cut down are related to:
- The Exception handling #131 
- The input arguments #140 

Note:
- These changes are not covered by regression tests.
- The output processing has not been refactored, just moved to `run.py`. This should be addressed in #185 

Fixes #138 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
