### PR TITLE
Fix `is_abbreviation`

### DIFF
--- a/autocorpus/abbreviation.py
+++ b/autocorpus/abbreviation.py
@@ -35,43 +35,27 @@ def _remove_quotes(text: str) -> str:
     return re2.sub(r'([(])[\'"\p{Pi}]|[\'"\p{Pf}]([);:])', r"\1\2", text)
 
 
-def _is_abbreviation(candidate: str) -> bool:
-    r"""Check whether input string is an abbreviation.
+def _is_abbreviation(s: str) -> bool:
+    """Check whether input string is an abbreviation.
 
-    Based on Schwartz&Hearst.
+    To be classified as an abbreviation, a string must be composed exclusively of
+    Unicode letters or digits, optionally separated by dots. This sequence must repeat
+    between two and ten times. We exclude strings that are *exclusively* composed of
+    digits or lowercase letters.
 
-    2 <= len(str) <= 10
-    len(tokens) <= 2
-    re.search(r'\p{L}', str)
-    str[0].isalnum()
-
-    and extra:
-    if it matches (\p{L}\.?\s?){2,}
-    it is a good candidate.
-
-    Args:
-        candidate: Candidate abbreviation
-
-    Returns:
-        True if this is a good candidate
+    Adapted from Schwartz & Hearst.
     """
-    viable = True
+    # Disallow if exclusively composed of digits
+    if re2.match(r"\p{N}+$", s):
+        return False
 
-    # Broken: See https://github.com/omicsNLP/Auto-CORPus/issues/144
-    # if re2.match(r"(\p{L}\.?\s?){2,}", candidate.lstrip()):
-    #     viable = True
-    if len(candidate) < 2 or len(candidate) > 10:
-        viable = False
-    if len(candidate.split()) > 2:
-        viable = False
-    if candidate.islower():  # customize function discard all lower case candidate
-        viable = False
-    if not re2.search(r"\p{L}", candidate):  # \p{L} = All Unicode letter
-        viable = False
-    if not candidate[0].isalnum():
-        viable = False
+    # Disallow if exclusively composed of lowercase unicode chars
+    if re2.match(r"\p{Ll}+$", s):
+        return False
 
-    return viable
+    # Should be a repeating sequence of unicode chars or digits, optionally separated
+    # by dots. The sequence must repeat between 2 and 10 times.
+    return bool(re2.match(r"([\p{L}\p{N}]\.?){2,10}$", s))
 
 
 def _get_definition(candidate: str, preceding: str) -> str:

--- a/tests/data/PMC/Current/PMC8885717_abbreviations.json
+++ b/tests/data/PMC/Current/PMC8885717_abbreviations.json
@@ -1,11 +1,11 @@
 {
   "source": "Auto-CORPus (abbreviations)",
-  "date": "20250326",
+  "date": "20250514",
   "key": "autocorpus_abbreviations.key",
   "documents": [
     {
       "id": "PMC8885717",
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "passages": [
         {
           "text_short": "NLP",
@@ -55,11 +55,6 @@
         {
           "text_short": "HDR",
           "text_long_1": "Health Data Research",
-          "extraction_algorithm_1": "fulltext"
-        },
-        {
-          "text_short": "CRIS-CODE",
-          "text_long_1": "Clinical Record Interactive Search Comprehensive Data Extraction",
           "extraction_algorithm_1": "fulltext"
         }
       ]

--- a/tests/data/PMC/Current/PMC8885717_bioc.json
+++ b/tests/data/PMC/Current/PMC8885717_bioc.json
@@ -1,12 +1,12 @@
 {
   "source": "Auto-CORPus (full-text)",
-  "date": "20250326",
+  "date": "20250514",
   "key": "autocorpus_fulltext.key",
   "infons": {},
   "documents": [
     {
       "id": "PMC8885717",
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "infons": {},
       "passages": [
         {

--- a/tests/data/PMC/Current/PMC8885717_tables.json
+++ b/tests/data/PMC/Current/PMC8885717_tables.json
@@ -1,11 +1,11 @@
 {
   "source": "Auto-CORPus (tables)",
-  "date": "20250326",
+  "date": "20250514",
   "key": "autocorpus_tables.key",
   "infons": {},
   "documents": [
     {
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "id": "1",
       "infons": {},
       "passages": [
@@ -782,7 +782,7 @@
       ]
     },
     {
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "id": "2",
       "infons": {},
       "passages": [
@@ -1139,7 +1139,7 @@
       ]
     },
     {
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "id": "3",
       "infons": {},
       "passages": [
@@ -1319,7 +1319,7 @@
       ]
     },
     {
-      "inputfile": "tests\\data\\PMC\\Current\\PMC8885717.html",
+      "inputfile": "tests/data/PMC/Current/PMC8885717.html",
       "id": "4",
       "infons": {},
       "passages": [

--- a/tests/data/PMC/Pre-Oct-2024/PMC8885717_abbreviations.json
+++ b/tests/data/PMC/Pre-Oct-2024/PMC8885717_abbreviations.json
@@ -1,6 +1,6 @@
 {
   "source": "Auto-CORPus (abbreviations)",
-  "date": "20240829",
+  "date": "20250514",
   "key": "autocorpus_abbreviations.key",
   "documents": [
     {
@@ -55,11 +55,6 @@
         {
           "text_short": "HDR",
           "text_long_1": "Health Data Research",
-          "extraction_algorithm_1": "fulltext"
-        },
-        {
-          "text_short": "CRIS-CODE",
-          "text_long_1": "Clinical Record Interactive Search Comprehensive Data Extraction",
           "extraction_algorithm_1": "fulltext"
         }
       ]

--- a/tests/data/PMC/Pre-Oct-2024/PMC8885717_bioc.json
+++ b/tests/data/PMC/Pre-Oct-2024/PMC8885717_bioc.json
@@ -1,6 +1,6 @@
 {
   "source": "Auto-CORPus (full-text)",
-  "date": "20240829",
+  "date": "20250514",
   "key": "autocorpus_fulltext.key",
   "infons": {},
   "documents": [

--- a/tests/data/PMC/Pre-Oct-2024/PMC8885717_tables.json
+++ b/tests/data/PMC/Pre-Oct-2024/PMC8885717_tables.json
@@ -1,6 +1,6 @@
 {
   "source": "Auto-CORPus (tables)",
-  "date": "20240829",
+  "date": "20250514",
   "key": "autocorpus_tables.key",
   "infons": {},
   "documents": [

--- a/tests/test_abbreviation.py
+++ b/tests/test_abbreviation.py
@@ -1,0 +1,42 @@
+"""Tests for the abbreviation module."""
+
+from itertools import chain, repeat
+
+import pytest
+
+from autocorpus.abbreviation import _is_abbreviation
+
+_ABBREVIATIONS = (
+    "ABC",
+    "H.P.",  # can be separated by dots
+    "A.BC",  # we don't enforce that there is a dot after every letter
+    "HOUSE",  # allowed: all caps
+    "House",  # allowed: at least one letter is capital (odd though)
+    "ÄBÇ",  # we support unicode chars
+    "3ABC",  # we allow numbers
+    "ABC3",
+    "A.B.3.",  # abbreviations with numbers can still be separated by dots
+    "a.b.c.",  # all lowercase strings are fine if separated by dots
+    "A.B." * 5,  # long string, but separated by dots, so also fine
+)
+_NON_ABBREVIATIONS = (
+    "",
+    "A",  # too short
+    "AB" * 6,  # too long
+    "3",  # disallowed: exclusively composed of digits
+    "A!B!C!",
+    "H.P.!",
+    "abc",  # disallowed: all lowercase
+    "house",
+    "äbç",  # disallowed: all lowercase (unicode)
+    "CRIS-CODE",  # hyphens not allowed
+)
+
+
+@pytest.mark.parametrize(
+    "s,expected",
+    chain(zip(_ABBREVIATIONS, repeat(True)), zip(_NON_ABBREVIATIONS, repeat(False))),
+)
+def test_is_abbreviation(s: str, expected: bool):
+    """Test the _is_abbreviation() function."""
+    assert _is_abbreviation(s) == expected

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -17,7 +17,10 @@ from autocorpus.configs.default_config import DefaultConfig
     ],
 )
 def test_autocorpus(data_path: Path, input_file: str, config: dict[str, Any]) -> None:
-    """A regression test for the main autoCORPus class, using the each PMC config on the AutoCORPus Paper."""
+    """A regression test for the main autoCORPus class.
+
+    Uses each PMC config on the AutoCORPus Paper.
+    """
     from autocorpus.autocorpus import Autocorpus
 
     pmc_example_path = data_path / input_file


### PR DESCRIPTION
# Description

As discussed, there are some shortcomings/bugs with the current method used to check whether or not a string is an abbreviation. I've had a go at reimplementing `is_abbreviation`; let me know what you think.

I'm opening this as a draft PR because it changes the behaviour of AC. We should get @jmp111 and/or @Antoinelfr to sign off on it before we merge.

I've described the checks we're doing in the docstring:

>    To be classified as an abbreviation, a string must be composed exclusively of
    Unicode letters or digits, optionally with a following dot. This sequence must
    repeat between two and ten times. We exclude strings that are *exclusively* composed
    of digits or lowercase letters.

I've added unit tests. The test cases are in `tests/test_abbreviation.py` and should give a sense of what is/isn't considered an abbreviation. If you think there's anything that we're classifying wrongly or any checks that we're not doing but should be, let me know.

From among the test cases, there are a few differences with the old implementation:

- An empty string was counted as an abbreviation
- Trailing characters were ignored so e.g. `"ABC!!!!"` would be counted as an abbreviation
- Lowercase letters separated by dots (e.g. `"a.b.c."`) **weren't** counted as abbreviations (now we only exclude strings if they're **exclusively** composed of lowercase letters)
- Five letters separated by dots **weren't** counted as an abbreviation (too long -- now we count letters/numbers instead)
- Strings with punctuation etc. between letters weren't properly excluded (e.g. `"A!&=B"` was counted as an abbreviation)

One consequence of the last change in that list is that one string in the Auto-CORPus paper which **was** previously considered an abbreviation isn't anymore. The string is `"CRIS-CODE"`, described as "Clinical Record Interactive Search Comprehensive Data Extraction". Not sure if we should be counting that as an abbreviation or not? If so, we may want to allow hyphens as separators as well as dots.

Fixes #144.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
