### PR TITLE
Skip the PDF regression test in MacOS if running in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
-        run: poetry run pytest
+        run: poetry run pytest --ci
       - name: Check docs build
         run: poetry run mkdocs build
       - name: Check types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run tests
-        run: poetry run pytest --ci
+        run: poetry run pytest --skip-ci-macos
       - name: Check docs build
         run: poetry run mkdocs build
       - name: Check types

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,12 +80,12 @@ def sample_collection() -> BioCCollection:
 
 
 def pytest_addoption(parser):
-    """Fixture to add command line options for pytest."""
+    """Hook function to add custom command line options for pytest."""
     parser.addoption(
-        "--ci",
+        "--skip-ci-macos",
         action="store_true",
         default=False,
-        help="Indicate tests are running in CI",
+        help="Skip tests that are unable to run in CI on macOS",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,8 +98,8 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Fixture to modify test collection based on command line options."""
-    if not config.getoption("--ci"):
-        # `--ci` not given in cli: this is not a CI run
+    if not config.getoption("--skip-ci-macos"):
+        # `--skip-ci-macos` not given in cli: this is not a CI run
         return
     skip_ci_macos = pytest.mark.skipif(
         sys.platform == "darwin", reason="Uses too much memory in CI on MacOS"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for tests."""
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -76,3 +77,33 @@ def sample_collection() -> BioCCollection:
             )
         ],
     )
+
+
+def pytest_addoption(parser):
+    """Fixture to add command line options for pytest."""
+    parser.addoption(
+        "--ci",
+        action="store_true",
+        default=False,
+        help="Indicate tests are running in CI",
+    )
+
+
+def pytest_configure(config):
+    """Fixture to add custom markers to pytest."""
+    config.addinivalue_line(
+        "markers", "skip_ci_macos: mark test as unable to run in CI on MacOS"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Fixture to modify test collection based on command line options."""
+    if not config.getoption("--ci"):
+        # `--ci` not given in cli: this is not a CI run
+        return
+    skip_ci_macos = pytest.mark.skipif(
+        sys.platform == "darwin", reason="Uses too much memory in CI on MacOS"
+    )
+    for item in items:
+        if "skip_ci_macos" in item.keywords:
+            item.add_marker(skip_ci_macos)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -60,6 +60,7 @@ def test_autocorpus(data_path: Path, input_file: str, config: dict[str, Any]) ->
     assert tables == expected_tables
 
 
+@pytest.mark.skip_ci_macos
 @pytest.mark.parametrize(
     "input_file, config",
     [


### PR DESCRIPTION
# Description

This PR creates the `--skip-ci-macos` command line flag for pytest to indicated when the tests are running in CI and should skip certain tests (and makes it usable locally). When this flag is used, tests will be skipped for the MacOS CI runners if they are marked with

```python
@pytest.mark.skip_ci_macos
```

Fixes #248 

**Note:** This builds on #235 and targets it as the base branch. I should note that the tests are failing for me locally on my MacOS machine, so this PR is covering that up. The differences appear to be minor:

<img width="1328" alt="Screenshot 2025-05-19 at 17 08 29" src="https://github.com/user-attachments/assets/0c883a27-ef23-4d55-a4f0-ba14acd4ca92" />

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
