### PR TITLE
Make tables output file ordering deterministic

### DIFF
--- a/autocorpus/table.py
+++ b/autocorpus/table.py
@@ -449,7 +449,9 @@ def get_table_json(
             first_col_vals = [
                 i for i in first_col if first_col.index(i) not in header_idx
             ]
-            unique_vals = set(i for i in first_col_vals if i not in ("", "None"))
+            unique_vals = dict.fromkeys(
+                i for i in first_col_vals if i not in ("", "None")
+            )
             if len(unique_vals) <= len(first_col_vals) / 2:
                 section_names = list(unique_vals)
                 for i in section_names:


### PR DESCRIPTION
# Description

`get_table_json()` currently uses a set to filter out duplicate values, but then iterates over the contents. As sets have non-deterministic ordering, this means you get different results on different runs of AC.

Fix by replacing with a `dict` (which does have deterministic ordering).

While the ordering of the properties in the output files doesn't particularly matter per se, if the ordering changes between runs of AC it makes it harder to compare results with previous runs (e.g. with regression tests), so let's keep it consistent.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
