### PR TITLE
README.md: Use built-in config argument for example usage

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,8 +10,8 @@
       "request": "launch",
       "module": "autocorpus",
       "args": [
-        "-c",
-        "${workspaceFolder}/autocorpus/configs/config_pmc.json",
+        "-b",
+        "PMC",
         "-t",
         "output",
         "-f",
@@ -24,8 +24,8 @@
       "request": "launch",
       "module": "autocorpus",
       "args": [
-        "-c",
-        "${workspaceFolder}/autocorpus/configs/config_pmc_pre_oct_2024.json",
+        "-b",
+        "LEGACY_PMC",
         "-t",
         "output",
         "-f",

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ pip install autocorpus[pdf]
 
 ## Usage
 
-Run the below command for a single file example
+You can run Auto-CORPus on a single file like so:
 
 ```sh
-auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/html/file" -o JSON
+auto-corpus -b PMC -t "output" -f "path/to/html/file" -o JSON
 ```
 
-Run the main app for a directory of files example
+Auto-CORPus can also process whole directories:
 
 ```sh
-auto-corpus -c "autocorpus/configs/config_pmc.json" -t "output" -f "path/to/directory/of/html/files" -o JSON
+auto-corpus -b PMC -t "output" -f "path/to/directory/of/html/files" -o JSON
 ```
 
 ### Available arguments


### PR DESCRIPTION
I noticed this a while ago and forgot to put in a PR. The README still suggests passing a path to a config file when running AC. It would be better to point them to using one of the default configs (with the `-b` flag).

I also changed the VS Code debug config to use the `-b` flag too.